### PR TITLE
Change logical `and` and `or` to use `&&` and `||` symbols

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -68,7 +68,7 @@ let char = '\''character '\''
 
 rule token = parse
   | "_" { HOLE }
-  | "and" { AND }
+  | "&&" { LOGICAL_AND }
   | "as" { AS }
   | "do" { DO }
   | "else" { ELSE }
@@ -81,7 +81,7 @@ rule token = parse
   | "..." { INCLUDE }
   | "let" { LET }
   | "local" { LOCAL }
-  | "or" { OR }
+  | "||" { LOGICAL_OR }
   | "wrap" { WRAP }
   | "primitive" { PRIMITIVE }
   | "rec" { REC }

--- a/parser.mly
+++ b/parser.mly
@@ -27,7 +27,7 @@ let parse_error s = raise (Source.Error (Source.nowhere_region, s))
 
 %token HOLE PRIMITIVE
 %token FUN REC LET LOCAL IN DO WRAP UNWRAP TYPE INCLUDE END
-%token IF THEN ELSE OR AND AS
+%token IF THEN ELSE LOGICAL_OR LOGICAL_AND AS
 %token EQUAL COLON SEAL ARROW DARROW
 %token WITH
 %token LPAR RPAR
@@ -298,9 +298,9 @@ infexp :
     { appE(VarE($1)@@ati(1), $2)@@at() }
   | infexp sym appexp
     { appE(appE(VarE($2)@@ati(2), $1)@@at(), $3)@@at() }
-  | infexp OR appexp
+  | infexp LOGICAL_OR appexp
     { orE($1, $3)@@at() }
-  | infexp AND appexp
+  | infexp LOGICAL_AND appexp
     { andE($1, $3)@@at() }
   | DO appexp
     { doE($2)@@at() }

--- a/prelude.1ml
+++ b/prelude.1ml
@@ -225,7 +225,7 @@ type SET =
 Set (Elem : ORD) :> SET with (elem = Elem.t) =
 {
   type elem = Elem.t;
-  (==) x y = let include Elem in (x <= y) and (y <= x);
+  (==) x y = let include Elem in (x <= y) && (y <= x);
   type set = (int, elem -> bool);
   type t = set;
   empty = (0, fun (x : elem) => false);
@@ -233,7 +233,7 @@ Set (Elem : ORD) :> SET with (elem = Elem.t) =
   mem (x : elem) (s : set) = s._2 x;
   add (x : elem) (s : set) =
     if mem x s then s
-    else (s._1 + 1, fun (y : elem) => x == y or mem y s) : set;
+    else (s._1 + 1, fun (y : elem) => x == y || mem y s) : set;
 };
 
 
@@ -252,7 +252,7 @@ type MAP =
 Map (Key : ORD) :> MAP with (key = Key.t) =
 {
   type key = Key.t;
-  (==) x y = let include Key in (x <= y) and (y <= x);
+  (==) x y = let include Key in (x <= y) && (y <= x);
   type map a = key -> opt a;
   t = map;
   empty x = none;

--- a/russo.1ml
+++ b/russo.1ml
@@ -65,7 +65,7 @@ type STREAM =
 };
 
 divides k n =
-  let loop = rec loop => fun i => (i * k == n) or ((i * k < n) and loop (i + 1))
+  let loop = rec loop => fun i => (i * k == n) || ((i * k < n) && loop (i + 1))
   in loop 1;
 
 sift (S : STREAM) :> STREAM =

--- a/test.1ml
+++ b/test.1ml
@@ -239,7 +239,7 @@ Set (Elem : ORD) :> SET with (elem = Elem.t) =
   mem (x : elem) (s : set) = s._2 x;
   add (x : elem) (s : set) =
     if mem x s then s
-    else (s._1 + 1, fun (y : elem) => x == y or mem y s) : set;
+    else (s._1 + 1, fun (y : elem) => x == y || mem y s) : set;
 };
 
 do log "Map";


### PR DESCRIPTION
The reason for this change is to free the `and` symbol for use in recursive
definitions.