### PR TITLE
Remove `local-in-end` and `include` from the syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ T ::=
 (declarations)
 D ::=
     X : T                   (field/member declaration)
-    include T               (type/signature inclusion)
+    ... T                   (type/signature inclusion)
     D ; D                   (sequencing)
                             (empty)
 
@@ -124,7 +124,7 @@ E ::=
 (bindings)
 B ::=
     X = E                   (field/member definition)
-    include E               (record/structure inclusion)
+    ... E                   (record/structure inclusion)
     B ; B                   (sequencing)
                             (empty)
     type_error E            (type error assertion - elaboration of E must fail)
@@ -168,12 +168,10 @@ A ::=
 
 (declarations)
 D ::= ...
-    ...T                            ~> include T
     X A1 ... An : T                 ~> X : A1 -> ... -> An -> T
     X A1 ... An = E                 ~> X : A1 -> ... -> An -> (= E)
     type X A1 ... An                ~> X : A1 => ... => An => type
     type X A1 ... An = T            ~> X : A1 => ... => An => (= type T)
-    local B in D end                ~> include (let B in {D})
 
 (expressions)
 E ::= ...
@@ -205,22 +203,20 @@ P ::=
     {..., type X A1 ... An, ...}    ~> {..., X : A1 => ... => An => type, ...}
     (P1, ..., Pn)                   ~> {_1 = P1, ..., _n = Pn}
     (type X A1 ... An)              ~> (X : A1 => ... => An => type)
-    wrap P : T                      ~> local $ = unwrap $ : T in P = $ end
-    @T P                            ~> local $ = $.@T in P = $ end
+    wrap P : T                      ~> ...let $ = unwrap $ : T in {P = $}
+    @T P                            ~> ...let $ = $.@T in {P = $}
     P : T                           ~> P = $ : T
     P1 as P2                        ~> P1; P2
 
 (bindings)
 B ::= ...
-    ...E                            ~> include E
     X                               ~> X = X
-    P = E                           ~> local $ = E in P end
+    P = E                           ~> ...let $ = E in {P}
     X A1 ... An = E                 ~> X = fun A1 ... An => E
     X A1 ... An : T = E             ~> X = fun A1 ... An => E : T
     X A1 ... An :> T = E            ~> X = fun A1 ... An => E :> T
     type X A1 ... An = T            ~> X = fun A1 ... An => type T
-    local B1 in B2 end              ~> include (let B1 in {B2})
-    do E                            ~> local _ = E in end
+    do E                            ~> ...let _ = E in {}
 ```
 
 Note [1]: The expansion of an argument `X` to `(X : type)` is only used for the

--- a/lexer.mll
+++ b/lexer.mll
@@ -72,15 +72,12 @@ rule token = parse
   | "as" { AS }
   | "do" { DO }
   | "else" { ELSE }
-  | "end" { END }
   | "type_error" { TYPE_ERROR }
   | "fun" { FUN }
   | "if" { IF }
   | "in" { IN }
-  | "include" { INCLUDE }
-  | "..." { INCLUDE }
+  | "..." { ELLIPSIS }
   | "let" { LET }
-  | "local" { LOCAL }
   | "||" { LOGICAL_OR }
   | "wrap" { WRAP }
   | "primitive" { PRIMITIVE }

--- a/parser.mly
+++ b/parser.mly
@@ -26,7 +26,7 @@ let parse_error s = raise (Source.Error (Source.nowhere_region, s))
 %}
 
 %token HOLE PRIMITIVE
-%token FUN REC LET LOCAL IN DO WRAP UNWRAP TYPE INCLUDE END
+%token FUN REC LET IN DO WRAP UNWRAP TYPE ELLIPSIS
 %token IF THEN ELSE LOGICAL_OR LOGICAL_AND AS
 %token EQUAL COLON SEAL ARROW DARROW
 %token WITH
@@ -188,10 +188,8 @@ atdec :
   | TYPE head typparamlist EQUAL typ
     { VarD($2, funT($3, EqT(TypE($5)@@ati 5)@@ati 5, Pure@@ati 4)@@at())
         @@at() }
-  | INCLUDE typ
+  | ELLIPSIS typ
     { InclD($2)@@at() }
-  | LOCAL bind IN dec END
-    { letD($2, $4)@@at() }
 /*
   | LPAR dec RPAR
     { $2 }
@@ -363,10 +361,8 @@ atbind :
     { VarB($1, VarE($1.it@@at())@@at())@@at() }
   | TYPE head typparamlist EQUAL typ
     { VarB($2, funE($3, TypE($5)@@ati 5)@@span[ati 3; ati 5])@@at() }
-  | INCLUDE exp
+  | ELLIPSIS exp
     { InclB($2)@@at() }
-  | LOCAL bind IN bind END
-    { letB($2, $4)@@at() }
   | DO exp
     { doB($2)@@at() }
   | TYPE_ERROR exp

--- a/prelude.1ml
+++ b/prelude.1ml
@@ -10,7 +10,7 @@ Fun =
   curry f x y = f (x, y);
   uncurry f (x, y) = f x y;
 };
-include Fun;
+...Fun;
 
 
 ;; Bool
@@ -35,8 +35,8 @@ PolyEq (type t) = {
 };
 
 Bool = {
-  include Bool;
-  include PolyEq t;
+  ...Bool;
+  ...PolyEq t;
 };
 
 ;; Int
@@ -55,7 +55,7 @@ Int =
   (<=) l r = primitive "Int.<=" (l, r);
   (>=) l r = primitive "Int.>=" (l, r);
   print = primitive "Int.print";
-  include PolyEq t;
+  ...PolyEq t;
 };
 type int = Int.t;
 (+) = Int.+;
@@ -79,7 +79,7 @@ Char =
   toInt = primitive "Char.toInt";
   fromInt = primitive "Char.fromInt";
   print = primitive "Char.print";
-  include PolyEq t;
+  ...PolyEq t;
 };
 type char = Char.t;
 
@@ -99,7 +99,7 @@ Text =
   sub t i = primitive "Text.sub" (t, i);
   fromChar c = primitive "Text.fromChar" c;
   print = primitive "Text.print";
-  include PolyEq t;
+  ...PolyEq t;
 };
 type text = Text.t;
 (++) = Text.++;
@@ -122,7 +122,7 @@ Opt :> OPT =
   some 'a x = wrap (fun (b : type) (n : () -> b) (s : a -> b) => s x) : opt a;
   caseopt xo = (unwrap xo : opt _) _;
 };
-include Opt;
+...Opt;
 
 
 ;; Alt
@@ -143,7 +143,7 @@ Alt :> ALT =
     wrap (fun (c : type) (l : a -> c) (r : b -> c) => r x) : alt a b;
   casealt xy = (unwrap xy : alt _ _) _;
 };
-include Alt;
+...Alt;
 
 
 ;; List
@@ -157,7 +157,7 @@ type LIST_CORE =
 };
 type LIST =
 {
-  include LIST_CORE;
+  ...LIST_CORE;
   caselist 'a 'b : list a -> (() -> b) -> (a -> list a -> b) -> b;
   isNil 'a : list a -> bool;
   head 'a : list a -> opt a;
@@ -172,7 +172,7 @@ type LIST =
 };
 List :> LIST =
 {
-  include
+  ...
   {
     type list a = wrap (b : type) => b -> (a -> b -> b) -> b;
     nil 'a = wrap (fun (b : type) (n : b) (c : a -> b -> b) => n) : list _;
@@ -200,7 +200,7 @@ List :> LIST =
     ) ).2;
 };
 
-include List;
+...List;
 
 
 ;; Set
@@ -225,7 +225,7 @@ type SET =
 Set (Elem : ORD) :> SET with (elem = Elem.t) =
 {
   type elem = Elem.t;
-  (==) x y = let include Elem in (x <= y) && (y <= x);
+  (==) x y = let ...Elem in (x <= y) && (y <= x);
   type set = (int, elem -> bool);
   type t = set;
   empty = (0, fun (x : elem) => false);
@@ -252,7 +252,7 @@ type MAP =
 Map (Key : ORD) :> MAP with (key = Key.t) =
 {
   type key = Key.t;
-  (==) x y = let include Key in (x <= y) && (y <= x);
+  (==) x y = let ...Key in (x <= y) && (y <= x);
   type map a = key -> opt a;
   t = map;
   empty x = none;

--- a/regression.1ml
+++ b/regression.1ml
@@ -142,12 +142,12 @@ in {
   case 'x 'n (type p _) (cs: I x p t) e =
     (unwrap e.@(t _ _): wrap T x n t) p cs;
 
-  local
+  ...let
     mk 'x 'n (c: T x n t) = @(t x n) (wrap c: wrap T x n t);
-  in
+  in {
     nil  'x                       = mk (fun (type p _) (r: I x p t) => r.nil);
     (::) 'x 'n (v: x) (vs: t x n) = mk (fun (type p _) (r: I x p t) => r.:: v vs);
-  end;
+  };
 } :> {
   type t _ _;
 

--- a/syntax.ml
+++ b/syntax.ml
@@ -78,7 +78,6 @@ let letE(b, e) =
   DotE(StrE(SeqB(b, b2)@@span[b.at; e.at])@@span[b.at; e.at], x'@@e.at)
 
 let letT(b, t) = PathT(letE(b, TypE(t)@@t.at)@@span[b.at; t.at])
-let letD(b, d) = InclD(letT(b, StrT(d)@@d.at)@@span[b.at; d.at])
 let letB(b, b') = InclB(letE(b, StrE(b')@@b'.at)@@span[b.at; b'.at])
 
 let rec tupT(ts) = StrT(tupT' 1 ts)

--- a/talk.1ml
+++ b/talk.1ml
@@ -135,7 +135,7 @@ do print "\n";
 
 ;; couple of dummies...
 datasize = 117;
-OrderedMap = Map {include Int; eq = (==)} :> MAP;
-HashMap = Map {include Int; eq = (==)} :> MAP;
+OrderedMap = Map {...Int; eq = (==)} :> MAP;
+HashMap = Map {...Int; eq = (==)} :> MAP;
 
 Map = if datasize <= 100 then OrderedMap else HashMap : MAP;

--- a/test.1ml
+++ b/test.1ml
@@ -93,7 +93,7 @@ Opt :> OPT =
   some x = wrap (fun (b : type) (n : b) (s : _ -> b) => s x) : opt _;
   caseopt xo = (unwrap xo : opt _) _;
 };
-include Opt;
+...Opt;
 
 do log "Alt";
 
@@ -111,7 +111,7 @@ Alt :> ALT =
   right x = wrap (fun (c : type) (l : _ -> c) (r : _ -> c) => r x) : alt _ _;
   casealt xy = (unwrap xy : alt _ _) _;
 };
-include Alt;
+...Alt;
 
 do log "List";
 
@@ -124,7 +124,7 @@ type LIST_CORE =
 };
 type LIST =
 {
-  include LIST_CORE;
+  ...LIST_CORE;
   caselist 'a 'b : list a -> b -> (a -> list a -> b) -> b;
   isNil 'a : list a -> bool;
   head 'a : list a -> opt a;
@@ -139,7 +139,7 @@ type LIST =
 };
 List :> LIST =
 {
-  include
+  ...
   {
     type list a = wrap (b : type) => b -> (a -> b -> b) -> b;
     nil = wrap (fun (b : type) (n : b) (c : _ -> b -> b) => n) : list _;
@@ -208,7 +208,7 @@ List :> LIST =
 };
 ;)
 
-include List;
+...List;
 
 do log "Set";
 
@@ -274,13 +274,13 @@ TestSetAndMap =
 };
 
 
-local
+...let
   f x = nil;
   g 'a : () -> list a = f;
-in
+in {
   G (type t) =
   {
-    include {type u = t; v = nil} :> {type u; v : list u};
+    ...{type u = t; v = nil} :> {type u; v : list u};
     y = g ();
     y1 = g () : list int;
     y2 = g () : list t;
@@ -291,7 +291,7 @@ in
   y2 = (G(type bool)).y : list bool;
   M = G(type bool);
   type_error M.y : list (M.u);
-end;
+};
 
 
 type int = primitive "int";


### PR DESCRIPTION
First of all `include` is superfluous and verbose compared to ellipsis `...`.

Also `local-in-end` is not significantly shorter than its encoding using `...`
and `let-in`:

```diff
- local X in Y end
+ ...let X in {Y}
```

Probably one of the real reasons for having `local-in-end` in Standard ML is the
fact that modules are not first-class in SML.  With first-class modules the
construct is a simple combination of include `...` and `let-in`.

Given these it seems better to just remove both `local-in-end` and `include` to
simplify the syntax.