### PR TITLE
Remove `T_abs with (Path = T_sub)` and add `T_abs & T_sub` syntax...

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ T ::=
     (X : T) -> E            (pure function/functor/constructor type)
     '(X : T) -> E           (implicit function/functor/constructor type)
     (= E)                   (singleton/alias type)
-    T with .Xs = E          (type refinement)
+    T & T                   (type refinement)
     wrap T                  (impredicative wrapped type)
     _                       (type wildcard)
     T as T                  (layered type (both operands have to be equal))
@@ -153,8 +153,6 @@ T ::= ...
     T1 -> T2                        ~> (_ : T1) -> T2
     P ~> T                          ~> ($ : TP) ~> let P in T  [2]
     P -> T                          ~> ($ : TP) -> let P in T  [2]
-    T with .Xs A1 ... An = E        ~> T with .Xs = fun A1 ... An => E
-    T with type .Xs A1 ... An = T'  ~> T with .Xs = fun A1 ... An => type T'
     let B in T                      ~> (let B in type T)
     rec P => T                      ~> (rec P => type T)
 

--- a/basis/index.1ml
+++ b/basis/index.1ml
@@ -19,7 +19,7 @@ type SET = {
   card : set ~> int
 }
 
-Set (Elem : ORD) :> SET with (elem = Elem.t) = {
+Set (Elem : ORD) :> SET & {elem = Elem.t} = {
   type elem = Elem.t
   x == y = let ...Elem in (x <= y) && (y <= x)
   type set = (int, elem ~> bool)
@@ -44,7 +44,7 @@ type MAP = {
   lookup 'a : key -> map a ~> opt a
 }
 
-Map (Key : ORD) :> MAP with (key = Key.t) = {
+Map (Key : ORD) :> MAP & {key = Key.t} = {
   type key = Key.t
   x == y = let ...Key in (x <= y) && (y <= x)
   type map a = key ~> opt a

--- a/examples/fc.1ml
+++ b/examples/fc.1ml
@@ -48,12 +48,14 @@ AssociatedTypes = {
     insert: Elem.t -> t ~> t
   }
 
-  CollectEq (Elem: EQ) :> COLLECTS with (Elem = Elem) = {
+  CollectEq (Elem: EQ) :> COLLECTS & {Elem} = {
+    Elem
     empty = List.nil
     insert = List.::
   }
 
-  BitSet :> COLLECTS with (Elem = Char) = {
+  BitSet :> COLLECTS & {Elem = Char} = {
+    Elem = Char
     empty = List.nil
     insert = List.::
   }

--- a/lexer.mll
+++ b/lexer.mll
@@ -98,6 +98,7 @@ module Offside = struct
 
   let slack_of token =
     match token with
+    | AMP -> 2
     | SYM text -> String.length text + 1
     | _ -> 0
 
@@ -280,7 +281,7 @@ rule token = parse
   | "rec" { REC }
   | "then" { THEN }
   | "type" { TYPE }
-  | "with" { WITH }
+  | "&" { AMP }
   | "=" { EQUAL }
   | ":" { COLON }
   | ":>" { SEAL }

--- a/paper.1ml
+++ b/paper.1ml
@@ -65,7 +65,7 @@ type MAP = {
   lookup : (a : type) -> key -> map a ~> opt a
 }
 
-Map (Key : EQ) :> MAP with (type key = Key.t) = {
+Map (Key : EQ) :> MAP & {key = Key.t} = {
   type key = Key.t
   type map a = key ~> opt a
   empty (a : type) = fun (k : key) => none
@@ -141,7 +141,7 @@ joinM (M : MONAD) (a : type) (mm : M.t (M.t a)) : M.t a =
   M.bind (M.t a) a mm (fun (m : M.t a) => m)
 
 StackM (M : MONAD) =
-  rec (Loop : (n : int) ~> (MONAD_TRANS with (base = M.t))) =>
+  rec (Loop : (n : int) ~> (MONAD_TRANS & {base = M.t})) =>
   fun (n : int) =>
   if n == 1 then
     { ... M
@@ -162,7 +162,7 @@ StackM (M : MONAD) =
           (fun (mx : M.t a) => M.bind a b mx
             (fun (x : a) => f x))
     }
-  ) : MONAD_TRANS with (type base a = M.t a)
+  ) : MONAD_TRANS & {base = M.t}
 ;)
 
 ;; Predicativity
@@ -213,7 +213,7 @@ type MAP = {
   lookup 'a : key -> map a ~> opt a
   add 'a : key -> a -> map a ~> map a
 }
-Map (Key : EQ) :> MAP with (type key = Key.t) = {
+Map (Key : EQ) :> MAP & {key = Key.t} = {
   type key = Key.t
   type map a = key ~> opt a
   empty = fun x => none

--- a/prelude.1ml
+++ b/prelude.1ml
@@ -208,7 +208,7 @@ type SET = {
   card : set -> int
 }
 
-Set (Elem : ORD) :> SET with (elem = Elem.t) = {
+Set (Elem : ORD) :> SET & {elem = Elem.t} = {
   type elem = Elem.t
   x == y = let ...Elem in (x <= y) && (y <= x)
   type set = (int, elem ~> bool)
@@ -233,7 +233,7 @@ type MAP = {
   lookup 'a : key -> map a ~> opt a
 }
 
-Map (Key : ORD) :> MAP with (key = Key.t) = {
+Map (Key : ORD) :> MAP & {key = Key.t} = {
   type key = Key.t
   x == y = let ...Key in (x <= y) && (y <= x)
   type map a = key ~> opt a

--- a/regression.1ml
+++ b/regression.1ml
@@ -188,6 +188,9 @@ And = {
   type RDS = {A: {type t}, B: {type t}}
            & {A: {type t}, B: {v: A.t}}
            & {B: {type t}, A: {v: B.t}}
+
+  do {A = {t = bool, v = 1}, B = {t = int, v = true}} :> RDS
+  do {A = {t = bool, v = 1}, B = {t = int, v = true}} :  RDS
 }
 
 ;;

--- a/regression.1ml
+++ b/regression.1ml
@@ -170,6 +170,28 @@ Monadic = {
 
 ;;
 
+ExpressiveLanguageOfSignatures = {
+  type T = {type t, type u, x: t}
+  type V = {type t, type u, x: u}
+
+  type_error { type L = T & V }
+
+  type L1 = T & V & {type t, u = t}
+  type L2 = T & V & {x 'a: a}
+}
+
+And = {
+  type Reveal = {type t, x: t} & {t = int}
+  type Nested = {Nested: {type t, v: t}, x: Nested.t} & {Nested: {t = int}}
+  type RevealWithPath = {type t, toText: t ~> text} & (= Int)
+
+  type RDS = {A: {type t}, B: {type t}}
+           & {A: {type t}, B: {v: A.t}}
+           & {B: {type t}, A: {v: B.t}}
+}
+
+;;
+
 hole_is_allowed_type_pattern (type _ _) = ()
 
 typparams_allowed (id 'a: a -> a) ({alsoId 'x: x -> x}) =

--- a/sub.mli
+++ b/sub.mli
@@ -25,12 +25,18 @@ val string_of_error : error -> string
 
 val sub_typ :
   Env.env -> Types.typ -> Types.typ -> Types.typ list ->
-    Types.typ list * Types.infer ref list * Fomega.exp (* raise Sub *)
+    (Types.typ * Types.typ) list * Types.infer ref list * Fomega.exp (* raise Sub *)
 val sub_extyp :
   Env.env -> Types.extyp -> Types.extyp -> Types.typ list ->
-    Types.typ list * Types.infer ref list * Fomega.exp (* raise Sub *)
+    (Types.typ * Types.typ) list * Types.infer ref list * Fomega.exp (* raise Sub *)
 
 val equal_typ :
   Env.env -> Types.typ -> Types.typ -> Types.infer ref list (* raise Sub *)
 val equal_extyp :
   Env.env -> Types.extyp -> Types.extyp -> Types.infer ref list (* raise Sub *)
+
+val subst_of_match: (Types.typ * Types.typ) list -> (Types.var * Types.typ) list
+
+(* String conversion *)
+
+val string_of_match: (Types.typ * Types.typ) list -> string

--- a/syntax.ml
+++ b/syntax.ml
@@ -28,7 +28,7 @@ and typ' =
   | WrapT of typ
   | EqT of exp
   | AsT of typ * typ
-  | WithT of typ * var list * exp
+  | AndT of typ * typ
 
 and dec = (dec', unit) phrase
 and dec' =
@@ -386,7 +386,7 @@ let label_of_typ t =
   | WrapT _ -> "WrapT"
   | EqT _ -> "EqT"
   | AsT _ -> "AsT"
-  | WithT _ -> "WithT"
+  | AndT _ -> "AndT"
 
 let label_of_dec d =
   match d.it with
@@ -441,8 +441,8 @@ let rec string_of_typ t =
   | WrapT(t) -> node' [string_of_typ t]
   | EqT(e) -> node' [string_of_exp e]
   | AsT(t1, t2) -> node' [string_of_typ t1; string_of_typ t2]
-  | WithT(t, xs, e) ->
-    node' ([string_of_typ t] @ List.map string_of_var xs @ [string_of_exp e])
+  | AndT(t1, t2) ->
+    node' [string_of_typ t1; string_of_typ t2]
 
 and string_of_dec d =
   let node' = node (label_of_dec d) in
@@ -495,7 +495,7 @@ let rec imports_typ typ =
   | WrapT typ -> imports_typ typ
   | EqT exp -> imports_exp exp
   | AsT(typ1, typ2) -> imports_typ typ1 @ imports_typ typ2
-  | WithT(typ, _, exp) -> imports_typ typ @ imports_exp exp
+  | AndT(typ1, typ2) -> imports_typ typ1 @ imports_typ typ2
 
 and imports_dec dec =
   match dec.it with

--- a/talk.1ml
+++ b/talk.1ml
@@ -37,7 +37,7 @@ type MAP = {
   add : (a : type) -> key -> a -> map a ~> map a
 }
 
-Map (Key : EQ) :> MAP with (type key = Key.t) = {
+Map (Key : EQ) :> MAP & {key = Key.t} = {
   type key = Key.t
   type map a = key ~> opt a
   empty (a : type) = fun (x : key) => none
@@ -57,7 +57,7 @@ type MAP = {
   add 'a : key -> a -> map a ~> map a
 }
 
-Map (Key : EQ) :> MAP with (type key = Key.t) = {
+Map (Key : EQ) :> MAP & {key = Key.t} = {
   type key = Key.t
   type map a = key ~> opt a
   empty = fun x => none

--- a/test.1ml
+++ b/test.1ml
@@ -214,7 +214,7 @@ type SET = {
   card : set ~> int
 }
 
-Set (Elem : ORD) :> SET with (elem = Elem.t) = {
+Set (Elem : ORD) :> SET & {elem = Elem.t} = {
   type elem = Elem.t
   type set = (int, elem ~> bool)
   type t = set
@@ -237,7 +237,7 @@ type MAP = {
   lookup 'a : key -> map a ~> opt a
 }
 
-Map (Key : ORD) :> MAP with (key = Key.t) = {
+Map (Key : ORD) :> MAP & {key = Key.t} = {
   type key = Key.t
   type map a = key ~> opt a
   t = map

--- a/types.mli
+++ b/types.mli
@@ -97,7 +97,8 @@ val map_rowi : (lab -> 'a -> 'b) -> 'a row -> 'b row
 val intersect_row : 'a row -> 'a row -> 'a row
 val diff_row : 'a row -> 'a row -> 'a row
 
-val project_typ : lab list -> typ -> typ (* raise Not_found *)
+val intersect_typs : typ -> typ -> typ
+val merge_typs : typ -> typ -> typ
 
 
 (* Size check *)

--- a/types.mli
+++ b/types.mli
@@ -97,6 +97,7 @@ val map_rowi : (lab -> 'a -> 'b) -> 'a row -> 'b row
 val intersect_row : 'a row -> 'a row -> 'a row
 val diff_row : 'a row -> 'a row -> 'a row
 
+val has_typs : typ -> bool
 val intersect_typs : typ -> typ -> typ
 val merge_typs : typ -> typ -> typ
 


### PR DESCRIPTION
Remove `T_abs with (Path = T_sub)` and add `T_abs & T_sub` syntax for type refinement.

The new

    T_abs & T_sub

mechanism is similar to the old

    T_abs with (Path = T_sub)

mechanism and also to the include mechanism

    {...T_abs; ...T_sub}

The main difference is that, instead of using a path to target a specific substructure or requiring that no declarations overlap, an intersection, `T_int`, of the nested declarations of `T_abs` and `T_sub`, is computed.

Then it is checked whether `T_abs :> T_int` and if so a substitution, `𝛿`, is obtained.  Finally the nested declarations of `𝛿(T_abs)` and `T_sub` are merged.

Also, in `T1 & T2` both `T1` and `T2` are elaborated in the same environment whereas in `{...T1; ...T2}` the environment for `T2` includes declarations from `T1` and in `T1 with (P = T2)` the path `P` is specific to `T1`.

When defined, `T1 & T2` is always a subtype of both `T1` and `T2`

    T1 & T2  :>  T1
    T1 & T2  :>  T2