### PR TITLE
Add sugar for declaration punning

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ D ::= ...
     X A1 ... An = E                 ~> X : A1 -> ... -> An -> (= E)
     type X A1 ... An                ~> X : A1 => ... => An => type
     type X A1 ... An = T            ~> X : A1 => ... => An => (= type T)
+    X                               ~> X : (= X)
 
 (expressions)
 E ::= ...

--- a/parser.mly
+++ b/parser.mly
@@ -185,6 +185,8 @@ atdec :
   | head typparamlist EQUAL exp
     { VarD($1, funT($2, EqT($4)@@ati 4, Pure@@ati 3)@@span[ati 2; ati 4])
         @@at() }
+  | name
+    { VarD($1, funT([], EqT(VarE($1)@@ati 1)@@ati 1, Pure@@ati 1)@@ati 1)@@at() }
   | TYPE head typparamlist EQUAL typ
     { VarD($2, funT($3, EqT(TypE($5)@@ati 5)@@ati 5, Pure@@ati 4)@@at())
         @@at() }

--- a/regression.1ml
+++ b/regression.1ml
@@ -1,3 +1,7 @@
+type DEC_PUNNING = {int; list};
+
+;;
+
 Equivalence: {
   type t a b;
 


### PR DESCRIPTION
This is analogous to record (or definition or binding) punning where one can write e.g.

    x = 1;
    y = 2;
    xy = {x; y};  ;; same as {x = x; y = y}

Now that notation also exists for declarations.

This is motivated by the upcoming intersection like signature combination operator `&`.  Consider a `MAP` signature:

    type MAP = {
      type t _;
      Key: ORD;
      ;; ...
    };

With the declaration punning notation and intersection like combination, one could write

    Map (Key: ORD) :> MAP & {Key} = ;; ...

to refine the `MAP` signature.