### PR TITLE
Fix structure/record inference

### DIFF
--- a/elab.ml
+++ b/elab.ml
@@ -446,7 +446,7 @@ Trace.debug (lazy ("[FunE] env =" ^ VarSet.fold (fun a s -> s ^ " " ^ a) (domain
       | InferT(z) ->
         (* TODO: row polymorphism *)
         let t, zs = guess_typ (Env.domain_typ (add_typs aks env)) BaseK in
-        let tr = [l, t] in
+        let tr = [var.it, t] in
         resolve_always z (StrT(tr)); tr, zs
       | _ -> error exp1.at "expression is not a structure"
     in

--- a/regression.1ml
+++ b/regression.1ml
@@ -1,3 +1,7 @@
+record_inference x = x.works_a_little;
+
+;;
+
 type DEC_PUNNING = {int; list};
 
 ;;


### PR DESCRIPTION
The original code simply used a wrong variable in place of the field name.