### PR TITLE
Removed the duplicate `HOLE` rule of type expressions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
         homebrew:
           packages:
             - ocaml
+  allow_failures:
+    - os: osx
 
 git:
   depth: 5

--- a/parser.mly
+++ b/parser.mly
@@ -130,8 +130,6 @@ attyp :
     { PrimT($2)@@at() }
   | TYPE
     { TypT@@at() }
-  | HOLE
-    { HoleT@@at() }
   | LBRACE dec RBRACE
     { StrT($2)@@at() }
   | LPAR RPAR


### PR DESCRIPTION
The `HOLE` rule is now only a part of path expressions.  Removing the duplicate rule resolves a ton of reduce-reduce conflicts in the grammar.