### PR TITLE
Change `if-then-else` for nesting, to omit `else`, not need parens

### DIFF
--- a/elab.ml
+++ b/elab.ml
@@ -160,6 +160,11 @@ let rec instantiate env t e =
 
 (* Type Elaboration *)
 
+let split_annot exp =
+  match exp.it with
+  | EL.AnnotE(e, t) -> e, t
+  | _ -> exp, EL.HoleT@@exp.at
+
 let elab_impl env impl =
   match impl.it with
   | EL.Expl -> Explicit Pure
@@ -422,13 +427,14 @@ Trace.debug (lazy ("[FunE] env =" ^ VarSet.fold (fun a s -> s ^ " " ^ a) (domain
     ExT([], roll_t), Pure, zs1 @ zs2,
     IL.RollE(IL.AppE(f, IL.VarE(var.it)), erase_typ roll_t)
 
-  | EL.IfE(var, exp1, exp2, typ) ->
+  | EL.IfE(var, exp1, exp2) ->
     let t0, zs0, ex = elab_instvar env var in
     let _ =
       match t0 with
       | PrimT(Prim.BoolT) -> ()
       | InferT(z) -> resolve_always z (PrimT(Prim.BoolT))
       | _ -> error var.at "condition is not Boolean" in
+    let exp2, typ = split_annot exp2 in
     let ExT(aks, t) as s, zs = elab_typ env typ l in
     let s1, p1, zs1, e1 = elab_exp env exp1 l in
     let s2, p2, zs2, e2 = elab_exp env exp2 l in
@@ -573,6 +579,13 @@ Trace.debug (lazy ("[RecT] t = " ^ string_of_norm_typ t));
     | None -> Source.error path.at ("\""^path.it^"\" does not resolve to a file")
     | Some canonic ->
       ExT([], lookup_var env (canonic@@path.at)), Pure, [], IL.VarE(canonic))
+
+  | EL.AnnotE(e, t) ->
+    let exp =
+      let open Syntax in
+      let x' = var "annot" in
+      appE(FunE(x'@@t.at, t, VarE(x'@@t.at)@@t.at, Expl@@t.at)@@span[e.at; t.at], e)@@exp.at in
+    elab_exp env exp l
 
 (*
 rec (X : (b : type) => {type t; type u a}) fun (b : type) => {type t = (X int.u b, X bool.t); type u a = (a, X b.t)}

--- a/parser.mly
+++ b/parser.mly
@@ -366,18 +366,14 @@ annexp :
   | annexp annexp_op typ
     { $2($1, $3)@@at() }
 ;
-inexp :
-  | annexp
-    { $1 }
-  | IF exp THEN exp ELSE infexp optannot
-    { ifE($2, $4, $6, match $7 with None -> HoleT@@ati 1 | Some t -> t)@@at() }
-;
 exp :
   | LET bind IN exp
     { letE($2, $4)@@at() }
-  | inexp SEMI exp
+  | IF exp THEN exp ELSE exp
+    { ifE($2, $4, $6)@@at() }
+  | annexp SEMI exp
     { seqE($1, $3)@@at() }
-  | inexp
+  | annexp
     { $1 }
   | FUN param paramlist bindanns_opt DARROW exp
     { funE($2::$3, $4($6))@@at() }

--- a/prelude.1ml
+++ b/prelude.1ml
@@ -20,7 +20,7 @@ Bool = {
   true = primitive "true" ()
   false = primitive "false" ()
   not b = if b then false else true
-  print b = primitive "Text.print" (if b then "true" else "false")
+  print b = primitive "Text.print" if b then "true" else "false"
 }
 type bool = Bool.t
 true = Bool.true

--- a/regression.1ml
+++ b/regression.1ml
@@ -6,6 +6,22 @@ record_inference x = x.works_a_little
 
 ;;
 
+conditionals b : int =
+  if b then print "then1" else print "else1"
+  print "between"
+  if not b then
+    print "then2"
+    if b then print "then3"
+  else print "else2"
+  101
+
+aType i =
+  if i == 0 then int
+  else if i == 1 then text
+  else char : type
+
+;;
+
 type DEC_PUNNING = {int, list}
 
 ;;

--- a/russo.1ml
+++ b/russo.1ml
@@ -35,8 +35,12 @@ MkArray = rec (mkArray : int ~> ARRAY) => fun n =>
 
 printArray 't (A : ARRAY) (pr : t ~> ()) a =
   let loop = rec loop => fun i =>
-    if i == A.dim then print "\n"
-    else (pr (A.sub a i) ; print " " ; loop (i + 1))
+    if i == A.dim then
+      print "\n"
+    else
+      pr (A.sub a i)
+      print " "
+      loop (i + 1)
   loop 0
 
 A32 = MkArray 5
@@ -93,5 +97,5 @@ nthstate = rec (nthstate : int ~> Sieve.state) => fun n =>
 nthprime n = Sieve.value (nthstate n)
 
 printprimes = rec loop => fun n =>
-  if n == 0 then () else (loop (n - 1) ; Int.print (nthprime n) ; print "\n")
+  if n == 0 then () else loop (n - 1) ; Int.print (nthprime n) ; print "\n"
 do printprimes 20

--- a/syntax.ml
+++ b/syntax.ml
@@ -46,13 +46,14 @@ and exp' =
   | FunE of var * typ * exp * impl
   | WrapE of var * typ
   | RollE of var * typ
-  | IfE of var * exp * exp * typ
+  | IfE of var * exp * exp
   | DotE of exp * var
   | AppE of var * var
   | UnwrapE of var * typ
   | UnrollE of var * typ
   | RecE of var * typ * exp
   | ImportE of path
+  | AnnotE of exp * typ
 
 and bind = (bind', unit) phrase
 and bind' =
@@ -180,15 +181,17 @@ let doB(e) = letB(VarB("_"@@e.at, e)@@e.at, EmptyB@@e.at)
 let seqE(l, r) =
   letE(VarB("_"@@l.at, l)@@l.at, r)
 
-let ifE(e1, e2, e3, t) =
-  asVarE(e1, "if", fun x -> IfE(x, e2, e3, t)@@span[e1.at; t.at])
+let ifE(e1, e2, e3) =
+  let at = span[e1.at; e3.at] in
+  let ifE = asVarE(e1, "if", fun x -> IfE(x, e2, e3)@@at) in
+  match e3.it with
+  | AnnotE(_, t) -> AnnotE(ifE@@at, t)
+  | _ -> ifE
 
 let orE(e1, e2) =
-  ifE(e1, PrimE(Prim.BoolV(true))@@e1.at, e2,
-    PrimT("bool")@@span[e1.at; e2.at])
+  ifE(e1, PrimE(Prim.BoolV(true))@@e1.at, e2)
 let andE(e1, e2) =
-  ifE(e1, e2, PrimE(Prim.BoolV(false))@@e1.at,
-    PrimT("bool")@@span[e1.at; e2.at])
+  ifE(e1, e2, PrimE(Prim.BoolV(false))@@e1.at)
 
 let appE(e1, e2) =
   asVarE(e1, "app1", fun x1 ->
@@ -207,9 +210,7 @@ let rollE(e, t) =
 let unrollE(e, t) =
   asVarE(e, "unroll", fun x -> UnrollE(x, t)@@span[e.at; t.at])
 
-let annotE(e, t) =
-  let x' = var "annot" in
-  appE(FunE(x'@@t.at, t, VarE(x'@@t.at)@@t.at, Expl@@t.at)@@span[e.at; t.at], e)
+let annotE(e, t) = AnnotE(e, t)
 
 let sealE(e, t) =
   (* TODO: clone t! *)
@@ -384,6 +385,7 @@ let label_of_exp e =
   | UnrollE _ -> "UnrollE"
   | RecE _ -> "RecE"
   | ImportE _ -> "ImportE"
+  | AnnotE _ -> "AnnotE"
 
 let label_of_bind b =
   match b.it with
@@ -435,14 +437,15 @@ and string_of_exp e =
     node' [string_of_var x; string_of_typ t; string_of_exp e; string_of_impl i]
   | WrapE(x, t) -> node' [string_of_var x; string_of_typ t]
   | RollE(x, t) -> node' [string_of_var x; string_of_typ t]
-  | IfE(x, e1, e2, t) ->
-    node' [string_of_var x; string_of_exp e1; string_of_exp e2; string_of_typ t]
+  | IfE(x, e1, e2) ->
+    node' [string_of_var x; string_of_exp e1; string_of_exp e2]
   | DotE(e, x) -> node' [string_of_exp e; string_of_var x]
   | AppE(x1, x2) -> node' [string_of_var x1; string_of_var x2]
   | UnwrapE(x, t) -> node' [string_of_var x; string_of_typ t]
   | UnrollE(x, t) -> node' [string_of_var x; string_of_typ t]
   | RecE(x, t, e) -> node' [string_of_var x; string_of_typ t; string_of_exp e]
   | ImportE(p) -> node' ["\"" ^ String.escaped p.it ^ "\""]
+  | AnnotE(e, t) -> node' [string_of_exp e; string_of_typ t]
 
 and string_of_bind b =
   let node' = node (label_of_bind b) in
@@ -484,13 +487,14 @@ and imports_exp exp =
   | FunE(_, typ, exp, _) -> imports_typ typ @ imports_exp exp
   | WrapE(_, typ) -> imports_typ typ
   | RollE(_, typ) -> imports_typ typ
-  | IfE(_, exp1, exp2, typ) -> imports_exp exp1 @ imports_exp exp2 @ imports_typ typ
+  | IfE(_, exp1, exp2) -> imports_exp exp1 @ imports_exp exp2
   | DotE(exp, _) -> imports_exp exp
   | AppE _ -> []
   | UnwrapE(_, typ) -> imports_typ typ
   | UnrollE(_, typ) -> imports_typ typ
   | RecE(_, typ, exp) -> imports_typ typ @ imports_exp exp
   | ImportE path -> [path]
+  | AnnotE(exp, typ) -> imports_exp exp @ imports_typ typ
 
 and imports_bind bind =
   match bind.it with

--- a/test.1ml
+++ b/test.1ml
@@ -8,7 +8,7 @@ Bool = {
   true = primitive "true" ()
   false = primitive "false" ()
   not b = if b then false else true
-  print b = primitive "Text.print" (if b then "true" else "false")
+  print b = primitive "Text.print" if b then "true" else "false"
 }
 type bool = Bool.t
 true = Bool.true


### PR DESCRIPTION
The implementation introduces a separate `AnnotE` expression.  An `if-then-else` returning a value of a large type must have its `else` branch explicitly annotated.  The smart constructor for `IfE` expressions duplicates the annotation, if any, from the `else` branch to cover the whole `if-then-else` expression.  This approach has the advantage of keeping the grammar simple.  On the other hand, this requires minor changes to elaboration.

Additionally the lexer is changed to layout sensitively insert parentheses around `if-then-else` expressions and insert `else {}` in case an `if-then` ends without one.