### PR TITLE
Add `import` bindings and expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@
 NAME = 1ml
 MODULES = \
   lib source prim syntax parser lexer \
-  fomega types iL env erase trace sub elab \
+  fomega types iL env erase trace sub import elab \
   lambda compile \
   main
-NOMLI = syntax iL main
+NOMLI = syntax iL main import
 PARSERS = parser
 LEXERS = lexer
 SAMPLES = prelude paper

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ E ::=
     rec (X : T) => E        (recursion)
     @T E                    (recursive type roll)
     E.@T                    (recursive type unroll)
+    import "path"           (static import of module from file at path)
 
 (bindings)
 B ::=
@@ -228,6 +229,7 @@ B ::= ...
     let B in E                      ~> ...let B in E
     local B1 in B2                  ~> ...let B1 in {B2}  [4]
     do E                            ~> ...let _ = E in {}
+    import "path"                   ~> ...import "path"
 ```
 
 Note [1]: The expansion of an argument `X` to `(X : type)` is only used for the

--- a/basis/index.1ml
+++ b/basis/index.1ml
@@ -1,0 +1,55 @@
+import "prelude"
+
+List = import "./list"
+
+;; Set
+
+type ORD = {
+  type t
+  (<=) : t => t -> Bool.t
+}
+
+type SET = {
+  type set
+  type elem
+  type t = set
+  empty : set
+  add : elem -> set -> set
+  mem : elem -> set -> bool
+  card : set -> int
+}
+
+Set (Elem : ORD) :> SET with (elem = Elem.t) = {
+  type elem = Elem.t
+  x == y = let ...Elem in (x <= y) && (y <= x)
+  type set = (int, elem -> bool)
+  type t = set
+  empty = (0, fun (x : elem) => false)
+  card (s : set) = s._1
+  mem (x : elem) (s : set) = s._2 x
+  add (x : elem) (s : set) =
+    if mem x s then s
+    else (s._1 + 1, fun (y : elem) => x == y || mem y s) : set
+}
+
+
+;; Map
+
+type MAP = {
+  type map a
+  type key
+  type t a = map a
+  empty 'a : map a
+  add 'a : key -> a -> map a -> map a
+  lookup 'a : key -> map a -> opt a
+}
+
+Map (Key : ORD) :> MAP with (key = Key.t) = {
+  type key = Key.t
+  x == y = let ...Key in (x <= y) && (y <= x)
+  type map a = key -> opt a
+  t = map
+  empty x = none
+  lookup x m = m x
+  add x y m z = if x == z then some y else m x
+}

--- a/basis/list.1ml
+++ b/basis/list.1ml
@@ -1,0 +1,34 @@
+local import "prelude"
+
+...List
+
+isNil = case {nil = true, _::_ = false}
+
+head = case {nil = none, x::_ = some x}
+tail = case {nil = none, _::xs = some xs}
+
+foldr (::) nil = rec loop => case {nil, x::xs = x::loop xs}
+
+foldl xss = rec (loop: _ => _) => fun s => case {
+  nil = s
+  x :: xs = loop (xss x s) xs
+}
+
+length = foldl (const 1 >> (+)) 0
+
+nth = rec (loop: _ => _) => fun n => case {
+  nil = none
+  x :: xs = if n == 0 then some x else loop (n-1) xs
+}
+
+revPrependTo = foldl (::)
+rev = revPrependTo nil
+cat hs ts = revPrependTo ts (rev hs)
+
+map xy = foldl (xy >> (::)) nil >> rev
+
+filter p = foldl (fun x ys => if p x then x::ys else ys) nil >> rev
+
+flatMap xys = foldl (fun x ys => revPrependTo ys (xys x)) nil >> rev
+
+toText toText = rev >> foldl (fun x s => toText x ++ " :: " ++ s) "nil"

--- a/elab.ml
+++ b/elab.ml
@@ -568,6 +568,11 @@ Trace.debug (lazy ("[RecT] t = " ^ string_of_norm_typ t));
       ExT([], t), Pure, lift_warn exp.at t env (zs1 @ zs2 @ zs3),
       IL.LetE(e, "_", materialize_typ t)
     )
+  | EL.ImportE(path) ->
+    (match Import.resolve (Source.at_file path) path.it with
+    | None -> Source.error path.at ("\""^path.it^"\" does not resolve to a file")
+    | Some canonic ->
+      ExT([], lookup_var env (canonic@@path.at)), Pure, [], IL.VarE(canonic))
 
 (*
 rec (X : (b : type) => {type t; type u a}) fun (b : type) => {type t = (X int.u b, X bool.t); type u a = (a, X b.t)}

--- a/import.ml
+++ b/import.ml
@@ -1,0 +1,52 @@
+module S = Set.Make(String)
+
+let imports = ref S.empty
+
+let std_dir = Filename.dirname Sys.argv.(0)
+
+let mod_ext = ".1ml"
+let sig_ext = ".1mls"
+let index_file = "index"
+let modules_dir = "node_modules"
+
+let (<|>) xO uxO =
+  match xO with
+  | None -> uxO ()
+  | some -> some
+
+let finish path =
+  if Lib.Sys.file_exists_at path then
+    Some path
+  else
+    None
+
+let complete path =
+  if Lib.String.is_suffix mod_ext path then
+    finish path
+  else if Lib.Sys.directory_exists_at path then
+    finish (path ^ "/" ^ index_file ^ mod_ext)
+  else
+    finish (path ^ mod_ext)
+
+let rec search_modules prefix suffix =
+  complete (Filename.concat prefix modules_dir ^ "/" ^ suffix) <|> fun () ->
+  let parent = Filename.dirname prefix in
+  if parent = prefix then
+    None
+  else
+    search_modules parent suffix
+
+let resolve parent path =
+  let path = Lib.Filename.canonic path in
+  let path =
+    if Lib.String.is_suffix sig_ext path then
+      Lib.Filename.replace_ext sig_ext mod_ext path
+    else
+      path in
+  if not (Filename.is_relative path) then
+    complete path
+  else if Lib.String.is_prefix "./" path || Lib.String.is_prefix "../" path then
+    complete (Lib.Filename.canonic (Filename.dirname parent ^ "/" ^ path))
+  else
+    search_modules (Filename.dirname parent) path <|> fun () ->
+    complete (std_dir ^ "/" ^ path)

--- a/lexer.mll
+++ b/lexer.mll
@@ -232,6 +232,7 @@ rule token = parse
   | "||" { LOGICAL_OR }
   | "wrap" { WRAP }
   | "local" { LOCAL }
+  | "import" { IMPORT }
   | "primitive" { PRIMITIVE }
   | "rec" { REC }
   | "then" { THEN }

--- a/lib.ml
+++ b/lib.ml
@@ -4,6 +4,8 @@
 
 module List =
 struct
+  include List
+
   let rec last = function
     | x::[] -> x
     | x::xs -> last xs
@@ -36,9 +38,56 @@ end
 
 module String =
 struct
+  include String
+
   let is_prefix s1 s2 =
     String.length s1 <= String.length s2 &&
     s1 = String.sub s2 0 (String.length s1)
 
-  let split s n = (String.sub s 0 n, String.sub s n (String.length s - n))
+  let is_suffix s1 s2 =
+    let n1 = String.length s1 in
+    let n2 = String.length s2 in
+    n1 <= n2 && s1 = String.sub s2 (n2 - n1) n1
+
+  let drop s n = String.sub s n (String.length s - n)
+
+  let drop_last s n = String.sub s 0 (String.length s - n)
+
+  let split s n = (String.sub s 0 n, drop s n)
+
+  let index_from_opt s i c =
+    try Some (String.index_from s i c) with Not_found -> None
+
+  let split_on_char c s =
+    let rec loop ss i =
+      match index_from_opt s i c with
+      | None -> String.sub s i (String.length s - i) :: ss
+      | Some j -> loop (String.sub s i (j - i) :: ss) (j + 1) in
+    loop [] 0 |> List.rev
+end
+
+module Filename =
+struct
+  let canonic path =
+    let rec loop p s =
+      match p, s with
+      |       _,      [] -> p
+      |    _::_,  "."::s -> loop p s
+      |   ["."], ".."::s -> loop [".."] s
+      | ".."::_, ".."::s -> loop (".."::p) s
+      |    _::p, ".."::s -> loop p s
+      |       _,    n::s -> loop (n::p) s in
+    loop [] (String.split_on_char '/' path) |> List.rev |> String.concat "/"
+
+  let replace_ext ~before ~after ~path =
+    String.drop_last path (String.length before) ^ after
+end
+
+module Sys =
+struct
+  open Sys
+
+  let file_exists_at path = Sys.file_exists path && not (Sys.is_directory path)
+
+  let directory_exists_at path = Sys.file_exists path && Sys.is_directory path
 end

--- a/lib.mli
+++ b/lib.mli
@@ -16,5 +16,23 @@ end
 module String :
 sig
   val is_prefix : string -> string -> bool
+  val is_suffix : string -> string -> bool
+  val drop : string -> int -> string
+  val drop_last : string -> int -> string
   val split : string -> int -> string * string
+  val index_from_opt : string -> int -> char -> int option
+  val split_on_char : char -> string -> string list
+end
+
+module Filename :
+sig
+  val canonic : string -> string
+
+  val replace_ext : before: string -> after: string -> path: string -> string
+end
+
+module Sys :
+sig
+  val file_exists_at : string -> bool
+  val directory_exists_at : string -> bool
 end

--- a/main.ml
+++ b/main.ml
@@ -14,23 +14,50 @@ let run_f_flag = ref false
 
 let trace_phase name = if !trace_flag then print_endline ("-- " ^ name)
 
-let load file =
-  let f = open_in_bin file in
-  let size = in_channel_length f in
-  let source = really_input_string f size in
-  close_in f;
-  source
+let error at msg =
+  trace_phase "Error:";
+  prerr_endline (Source.string_of_region at ^ ": " ^ msg);
+  if not !interactive_flag then exit 1
 
-let parse name source =
+type source =
+  | Unsealed of string
+  | Sealed of string * string
+
+let load mod_path fake_path real_path =
+  let load_file file =
+    let file = if file = fake_path then real_path else file in
+    let f = open_in_bin file in
+    let size = in_channel_length f in
+    let source = really_input_string f size in
+    close_in f;
+    source in
+  let mod_source = load_file mod_path in
+  let sig_path = Lib.Filename.replace_ext Import.mod_ext Import.sig_ext mod_path in
+  if Lib.Sys.file_exists_at sig_path then
+    Sealed (mod_source, load_file sig_path)
+  else
+    Unsealed mod_source
+
+let parse_as production name source =
   let lexbuf = Lexing.from_string source in
   lexbuf.Lexing.lex_curr_p <-
     {lexbuf.Lexing.lex_curr_p with Lexing.pos_fname = name};
   let token = let open Lexer.Offside in token (init ()) Lexer.token in
-  try Parser.prog token lexbuf with Source.Error (region, s) ->
+  try production token lexbuf with Source.Error (region, s) ->
     let region' = if region <> Source.nowhere_region then region else
       {Source.left = Lexer.convert_pos lexbuf.Lexing.lex_start_p;
        Source.right = Lexer.convert_pos lexbuf.Lexing.lex_curr_p} in
     raise (Source.Error (region', s))
+
+let parse mod_name source =
+  match source with
+  | Unsealed mod_source -> parse_as Parser.prog mod_name mod_source
+  | Sealed (mod_source, sig_source) ->
+    let sig_name = Lib.Filename.replace_ext Import.mod_ext Import.sig_ext mod_name in
+    let exp = parse_as Parser.prog mod_name mod_source in
+    let typ = parse_as Parser.sigs sig_name sig_source in
+    let open Source in
+    Syntax.sealE(exp, typ)@@nowhere_region
 
 let env = ref Env.empty
 let state = ref Lambda.Env.empty
@@ -52,10 +79,44 @@ let print_sig s =
     Types.print_extyp s;
     print_endline ""
 
-let process file source =
+let rec process_imports prog =
+  let rec loop = function
+    | [] -> ()
+    | path::paths ->
+      let parent = Source.at_file path in
+      let at = Source.at path in
+      let path = Source.it path in
+      match Import.resolve parent path with
+      | None ->
+        Source.error at ("\""^path^"\" does not resolve to a module")
+      | Some canonic ->
+        if not (Import.S.mem canonic !Import.imports) then (
+          Import.imports := Import.S.add canonic !Import.imports;
+          let source = load canonic canonic canonic in
+          let prog = parse canonic source in
+          process_imports prog;
+          let Types.ExT(aks, t), _, fprog = Elab.elab !env prog in
+          env := Env.add_val canonic t (Env.add_typs aks !env);
+          if not !no_run_flag then
+            if !run_f_flag then
+              let closed_prog =
+                List.fold_right (fun (x, t, e1) e2 -> Fomega.LetE(e1, x, e2))
+                  !f_state fprog in
+              let e = Fomega.norm_exp closed_prog in
+              f_state := !f_state @ [(canonic, Erase.erase_typ t, e)]
+            else
+              let lambda = Compile.compile (Erase.erase_env !env) fprog in
+              let value = Lambda.eval !state lambda in
+              state := Lambda.Env.add canonic value !state
+        );
+        loop paths in
+  Syntax.imports_exp prog |> loop
+
+let process path source =
   try
     trace_phase "Parsing...";
-    let prog = parse file source in
+    let prog = parse path source in
+    process_imports prog;
     if !ast_flag then begin
       print_endline (Syntax.string_of_exp prog)
     end;
@@ -120,23 +181,33 @@ let process file source =
     end;
     env := Env.add_row typrow (Env.add_typs aks !env)
   with Source.Error (at, s) ->
-    trace_phase "Error:";
-    prerr_endline (Source.string_of_region at ^ ": " ^ s);
-    if not !interactive_flag then exit 1
+    error at s
 
-let process_file file =
-  trace_phase ("Loading (" ^ file ^ ")...");
-  let source = load file in
-  process file source
+let cwd = Sys.getcwd ()
+let cwf = cwd ^ "/."
+
+let process_file (fake_path, real_path) =
+  match Import.resolve cwf fake_path with
+  | None ->
+    error (Source.file_region "<command>")
+      ("\""^fake_path^"\" does not resolve to a module")
+  | Some canonic ->
+    trace_phase ("Loading (" ^ canonic ^ ")...");
+    let source = load canonic fake_path real_path in
+    process canonic source
 
 let rec process_stdin () =
   print_string (name ^ "> "); flush_all ();
   match try Some (input_line stdin) with End_of_file -> None with
   | None -> print_endline ""; trace_phase "Bye."
-  | Some source -> process "stdin" source; process_stdin ()
+  | Some source ->
+    let canonic = cwd ^ "/<stdin>" in
+    process canonic (Unsealed source); process_stdin ()
 
 let greet () =
   print_endline ("Version " ^ version)
+
+let fake_path = ref None
 
 let usage = "Usage: " ^ name ^ " [option] [file ...]"
 let argspec = Arg.align
@@ -155,14 +226,19 @@ let argspec = Arg.align
   "-ts", Arg.Set Trace.sub_flag, " trace subtyping";
   "-td", Arg.Set Trace.debug_flag, " debug output";
   "-vt", Arg.Unit Types.verbosest_on, " verbose types";
-  "-ut", Arg.Set Types.undecidable_flag, " allow undecidable subtyping"
+  "-ut", Arg.Set Types.undecidable_flag, " allow undecidable subtyping";
+  "-as", Arg.String (fun path -> fake_path := Some path),
+  " treat next file as if its path was as given"
 ]
 
 let () =
   Printexc.record_backtrace true;
   try
     let files = ref [] in
-    Arg.parse argspec (fun file -> files := !files @ [file]) usage;
+    Arg.parse argspec (fun file ->
+        match !fake_path with
+        | None -> files := !files @ [(file, file)]
+        | Some fake' -> files := !files @ [(fake', file)]; fake_path := None) usage;
     if !files = [] then interactive_flag := true;
     List.iter process_file !files;
     if !interactive_flag then process_stdin ()

--- a/paper.1ml
+++ b/paper.1ml
@@ -1,8 +1,9 @@
 ;; Examples from the 1ML paper
-;; (assumes prelude.1ml)
 ;;
 ;; Note: This is assuming full 1ML, so unlike in the first part of the paper,
 ;; explicit type parameters must be annotated as 'type'.
+
+local import "prelude.1ml"
 
 ;; Section 2: 1ML with Explicit Types
 

--- a/parser.mly
+++ b/parser.mly
@@ -36,6 +36,7 @@ let parse_error s = raise (Source.Error (Source.nowhere_region, s))
 %token COMMA SEMI
 %token TYPE_ERROR
 %token LOCAL
+%token IMPORT
 
 %token EOF
 
@@ -45,8 +46,9 @@ let parse_error s = raise (Source.Error (Source.nowhere_region, s))
 %token<char> CHAR
 %token<int> NUM
 
-%start prog
+%start prog sigs
 %type<Syntax.exp> prog
+%type<Syntax.typ> sigs
 
 %%
 
@@ -329,6 +331,8 @@ atexp :
     { match $2 with [e] -> e | es -> tupE(es)@@at() }
   | LPAR DOT label RPAR
     { dotopE($3)@@at() }
+  | IMPORT TEXT
+    { ImportE($2@@ati 2)@@at() }
 ;
 appexp :
   | dotexp
@@ -423,6 +427,8 @@ atbind :
     { TypeErrorB($2)@@at() }
   | LET bind IN exp
     { InclB(letE($2, $4)@@at())@@at() }
+  | IMPORT TEXT
+    { InclB(ImportE($2@@ati 2)@@at())@@at() }
 /*
   | LPAR bind RPAR
     { $2 }
@@ -511,6 +517,11 @@ decon :
 prog :
   | bind EOF
     { strE($1)@@at() }
+;
+
+sigs :
+  | dec EOF
+    { strT($1)@@at() }
 ;
 
 %%

--- a/prelude/index.1ml
+++ b/prelude/index.1ml
@@ -1,0 +1,129 @@
+import "./primitives"
+
+;;
+
+Bool = {
+  ...Bool
+  not b = if b then false else true
+  toText b = if b then "true" else "false"
+}
+
+;;
+
+Fun = {
+  type t a b = a -> b
+  id x = x
+  const x _ = x
+  bot = rec (bot: _ => _) => fun x => bot x
+  curry f x y = f (x, y)
+  uncurry f (x, y) = f x y
+  flip f x y = f y x
+  (f >> g) x = g (f x)
+  (f << g) x = f (g x)
+  x |> f = f x
+  f <| x = f x
+}
+
+;;
+
+Alt :> {
+  type t _ _
+  inl 'a 'b: a => t a b
+  inr 'a 'b: b => t a b
+  case 'a 'b 'o: {inl: a -> o, inr: b -> o} => t a b -> o
+} = {
+  type t a b = wrap 'o => {inl: a -> o, inr: b -> o} -> o
+  inl x = wrap (fun c => c.inl x): t _ _
+  inr x = wrap (fun c => c.inr x): t _ _
+  case c (wrap x: t _ _) = x c
+}
+
+Alt = {
+  local ...Fun
+  ...Alt
+  either inl inr = Alt.case {inl, inr}
+  plus f g = either (f >> inl) (g >> inr)
+}
+
+;;
+
+Opt = {
+  type t x = Alt.t (type {}) x
+  none = Alt.inl ()
+  some = Alt.inr
+  case {none, some} = Alt.case {inl () = none, inr = some}
+}
+
+;;
+
+Pair = {
+  type t a b = (a, b)
+  fst (x, _) = x
+  snd (_, y) = y
+  cross f g (x, y) = (f x, g y)
+  fork f g x = (f x, g x)
+}
+
+;;
+
+List = {
+  local ...Opt, ...Fun
+  ...rec {type t _} => {type t x = Opt.t (Pair.t x (t x))}
+  nil = @(t _) none
+  hd :: tl = @(t _) (some (hd, tl))
+  case {nil, (::)} x = x.@(t _) |> Opt.case {
+    none = nil
+    some (hd, tl) = hd :: tl
+  }
+}
+
+;;
+
+alt = Alt.t
+bool = Bool.t
+char = Char.t
+int = Int.t
+list = List.t
+opt = Opt.t
+text = Text.t
+
+;;
+
+(%) = Int.%
+(*) = Int.*
+(+) = Int.+
+(++) = Text.++
+(-) = Int.-
+(/) = Int./
+(::) = List.::
+(<) = Int.<
+(<<) = Fun.<<
+(<=) = Int.<=
+(<>) = Int.<>
+(<|) = Fun.<|
+(==) = Int.==
+(>) = Int.>
+(>=) = Int.>=
+(>>) = Fun.>>
+(|>) = Fun.|>
+bot = Fun.bot
+const = Fun.const
+cross = Pair.cross
+curry = Fun.curry
+either = Alt.either
+false = Bool.false
+flip = Fun.flip
+fork = Pair.fork
+fst = Pair.fst
+id = Fun.id
+inl = Alt.inl
+inr = Alt.inr
+nil = List.nil
+none = Opt.none
+not = Bool.not
+plus = Alt.plus
+print = Text.print
+snd = Pair.snd
+some = Opt.some
+true = Bool.true
+uncurry = Fun.uncurry

--- a/prelude/index.1mls
+++ b/prelude/index.1mls
@@ -1,0 +1,170 @@
+local
+  type bool = primitive "bool"
+  type char = primitive "char"
+  type int = primitive "int"
+  type text = primitive "text"
+
+;;
+
+Alt: {
+  type t _ _
+  inl 'a 'b: a => t a b
+  inr 'a 'b: b => t a b
+  case 'a 'b 'o: {inl: a -> o, inr: b -> o} => t a b -> o
+  either 'a 'b 'o: (a -> o) => (b -> o) => t a b -> o
+  plus 'a 'b 'c 'd: (a -> c) => (b -> d) => t a b -> t c d
+}
+
+;;
+
+Bool: {
+  type t = bool
+  (==): t => t => bool
+  (<>): t => t => bool
+  true: t
+  false: t
+  not: t => t
+  toText: t => text
+}
+
+;;
+
+Char: {
+  type t = char
+  (==): t => t => bool
+  (<>): t => t => bool
+  toInt: t => int
+  fromInt: int => t
+  print: t -> {}
+}
+
+;;
+
+Fun: {
+  type t a b = a -> b
+  id 'a: a => a
+  const 'a 'b: a => b => a
+  bot 'a 'b: a => b
+  curry 'a 'b 'c: ((a, b) -> c) => a => b -> c
+  uncurry 'a 'b 'c: (a -> b -> c) => (a, b) -> c
+  flip 'a 'b 'c: (a -> b -> c) => b => a -> c
+  (<<) 'a 'b 'c: (b -> c) => (a -> b) => a -> c
+  (>>) 'a 'b 'c: (a -> b) => (b -> c) => a -> c
+  (<|) 'a 'b: (a -> b) => a -> b
+  (|>) 'a 'b: a => (a -> b) -> b
+}
+
+;;
+
+Int: {
+  type t = int
+  (==): t => t => bool
+  (<>): t => t => bool
+  (<): t => t => bool
+  (>): t => t => bool
+  (<=): t => t => bool
+  (>=): t => t => bool
+  (+): t => t => t
+  (-): t => t => t
+  (*): t => t => t
+  (/): t => t => t
+  (%): t => t => t
+  toText: t => text
+  print: t -> {}
+}
+
+;;
+
+List: {
+  type t _
+  nil 'a: t a
+  (::) 'a: a => t a => t a
+  case 'a 'o: {nil: o, (::): a -> t a -> o} => t a -> o
+}
+
+;;
+
+Opt: {
+  type t _
+  none 'a: t a
+  some 'a: a => t a
+  case 'a 'o: {none: o, some: a -> o} => t a -> o
+}
+
+;;
+
+Pair: {
+  type t a b = (a, b)
+  fst 'a 'b: (a, b) => a
+  snd 'a 'b: (a, b) => b
+  cross 'a 'b 'c 'd: (a -> c) => (b -> d) => (a, b) -> (c, d)
+  fork 'a 'b 'c: (a -> b) => (a -> c) => a -> (b, c)
+}
+
+;;
+
+Text: {
+  type t = text
+  (==): t => t => bool
+  (<>): t => t => bool
+  (<): t => t => bool
+  (>): t => t => bool
+  (<=): t => t => bool
+  (>=): t => t => bool
+  (++): t => t => t
+  length: t => int
+  sub: t => int => char
+  fromChar: char => t
+  print: t -> {}
+}
+
+;;
+
+type alt a b = Alt.t a b
+type bool = Bool.t
+type char = Char.t
+type int = Int.t
+type list a = List.t a
+type opt a = Opt.t a
+type text = Text.t
+
+;;
+
+(%): int => int => int
+(*): int => int => int
+(+): int => int => int
+(++): text => text => text
+(-): int => int => int
+(/): int => int => int
+(::) 'a: a => list a => list a
+(<): int => int => bool
+(<<) 'a 'b 'c: (b -> c) => (a -> b) => a -> c
+(<=): int => int => bool
+(<>): int => int => bool
+(<|) 'a 'b: (a -> b) => a -> b
+(==): int => int => bool
+(>): int => int => bool
+(>=): int => int => bool
+(>>) 'a 'b 'c: (a -> b) => (b -> c) => a -> c
+(|>) 'a 'b: a => (a -> b) -> b
+bot 'a 'b: a => b
+const 'a 'b: a => b => a
+cross 'a 'b 'c 'd: (a -> c) => (b -> d) => (a, b) -> (c, d)
+curry 'a 'b 'c: ((a, b) -> c) => a => b -> c
+either 'a 'b 'o: (a -> o) => (b -> o) => alt a b -> o
+false: bool
+flip 'a 'b 'c: (a -> b -> c) => b => a -> c
+fork 'a 'b 'c: (a -> b) => (a -> c) => a -> (b, c)
+fst 'a 'b: (a, b) => a
+id 'a: a => a
+inl 'a 'b: a => alt a b
+inr 'a 'b: b => alt a b
+nil 'a: list a
+none 'a: opt a
+not: bool => bool
+plus 'a 'b 'c 'd: (a -> c) => (b -> d) => alt a b -> alt c d
+print: text -> {}
+snd 'a 'b: (a, b) => b
+some 'a: a => opt a
+true: bool
+uncurry 'a 'b 'c: (a -> b -> c) => (a, b) -> c

--- a/prelude/primitives.1ml
+++ b/prelude/primitives.1ml
@@ -1,0 +1,49 @@
+local PolyEq (type t) = {
+  (x : t) == (y : t) = primitive "==" t (x, y)
+  (x : t) <> (y : t) = primitive "<>" t (x, y)
+}
+
+Bool = {
+  type t = primitive "bool"
+  true = primitive "true" ()
+  false = primitive "false" ()
+  ...PolyEq t
+}
+
+Char = {
+  type t = primitive "char"
+  toInt = primitive "Char.toInt"
+  fromInt = primitive "Char.fromInt"
+  print = primitive "Char.print"
+  ...PolyEq t
+}
+
+Int = {
+  type t = primitive "int"
+  l + r = primitive "Int.+" (l, r)
+  l - r = primitive "Int.-" (l, r)
+  l * r = primitive "Int.*" (l, r)
+  l / r = primitive "Int./" (l, r)
+  l % r = primitive "Int.%" (l, r)
+  l < r = primitive "Int.<" (l, r)
+  l > r = primitive "Int.>" (l, r)
+  l <= r = primitive "Int.<=" (l, r)
+  l >= r = primitive "Int.>=" (l, r)
+  toText = primitive "Int.toText"
+  print = primitive "Int.print"
+  ...PolyEq t
+}
+
+Text = {
+  type t = primitive "text"
+  l ++ r = primitive "Text.++" (l, r)
+  l < r = primitive "Text.<" (l, r)
+  l > r = primitive "Text.>" (l, r)
+  l <= r = primitive "Text.<=" (l, r)
+  l >= r = primitive "Text.>=" (l, r)
+  length t = primitive "Text.length" t
+  sub t i = primitive "Text.sub" (t, i)
+  fromChar = primitive "Text.fromChar"
+  print = primitive "Text.print"
+  ...PolyEq t
+}

--- a/prim.ml
+++ b/prim.ml
@@ -125,6 +125,7 @@ let funs =
     def "Int.<=" (IntD & IntD) PureE BoolD (fun (i1, i2) -> i1 <= i2);
     def "Int.>=" (IntD & IntD) PureE BoolD (fun (i1, i2) -> i1 >= i2);
 
+    def "Int.toText" IntD PureE TextD string_of_int;
     def "Int.print" IntD ImpureE VoidD (fun i -> print_int i; flush_all ());
 
     def "Char.toInt" CharD PureE IntD Char.code;

--- a/regression.1ml
+++ b/regression.1ml
@@ -1,3 +1,7 @@
+local import "prelude"
+
+;;
+
 record_inference x = x.works_a_little
 
 ;;

--- a/regression.1ml
+++ b/regression.1ml
@@ -1,4 +1,4 @@
-local import "prelude"
+local import "basis"
 
 ;;
 
@@ -146,9 +146,10 @@ in {
       ...T.Odd
       make 'x (v: opt (T.Even.t x)) : T.Odd.t x = @(T.Odd.t x) v
       size 'x (v: T.Odd.t x) =
-        caseopt v.@(T.Odd.t x)
-          (fun () => 0)
-          (fun e => R.Even.size e)
+        v.@(T.Odd.t x) |> Opt.case {
+          none = 0
+          some e = R.Even.size e
+        }
     }
   }
 
@@ -191,9 +192,9 @@ PolyRec = {
 
   t_int = t int
 
-  hmm (x: t int) = casealt (x.@(t int))
+  hmm (x: t int) = flip Alt.case (x.@(t int))
 
-  t0 = @(t int) (right (@(t (type (int, int))) (left (0, 0))))
+  t0 = @(t int) (inr (@(t (type (int, int))) (inl (0, 0))))
 }
 
 N :> {

--- a/russo.1ml
+++ b/russo.1ml
@@ -1,3 +1,5 @@
+local import "prelude.1ml"
+
 ;; Dynamically-Sized Functional Arrays
 ;; After Russo 1998, Types for Modules, Section 7.3
 

--- a/source.ml
+++ b/source.ml
@@ -19,6 +19,9 @@ exception Error of region * string
 let nowhere_pos = {file = ""; line = 0; column = 0}
 let nowhere_region = {left = nowhere_pos; right = nowhere_pos}
 
+let file_pos file = {file; line = 0; column = 0}
+let file_region file = let pos = file_pos file in {left = pos; right = pos}
+
 let string_of_pos pos =
   string_of_int pos.line ^ "." ^ string_of_int (pos.column + 1)
 let string_of_region r =
@@ -42,6 +45,7 @@ let (@@@) phrase' regions = phrase'@@(span regions)
 let (<~) phrase sem = assert (phrase.sem = None); phrase.sem <- Some sem; sem
 let dup phrase = phrase.it@@phrase.at
 
+let at_file phrase = phrase.at.left.file
 let at phrase = phrase.at
 let it phrase = phrase.it
 let sem phrase = match phrase.sem with

--- a/source.mli
+++ b/source.mli
@@ -16,6 +16,9 @@ exception Error of region * string
 val nowhere_pos : pos
 val nowhere_region : region
 
+val file_pos : string -> pos
+val file_region : string -> region
+
 val string_of_pos : pos -> string
 val string_of_region : region -> string
 
@@ -28,6 +31,7 @@ val (@@@) : 'a -> region list -> ('a, 'b) phrase
 val (<~) : ('a, 'b) phrase -> 'b -> 'b
 val dup : ('a, 'b) phrase -> ('a, 'b) phrase
 
+val at_file : ('a, 'b) phrase -> string
 val at : ('a, 'b) phrase -> region
 val it : ('a, 'b) phrase -> 'a
 val sem : ('a, 'b) phrase -> 'b

--- a/syntax.ml
+++ b/syntax.ml
@@ -5,6 +5,7 @@
 open Source
 
 type var = (string, unit) phrase
+type path = (string, unit) phrase
 
 type impl = (impl', unit) phrase
 and impl' =
@@ -51,6 +52,7 @@ and exp' =
   | UnwrapE of var * typ
   | UnrollE of var * typ
   | RecE of var * typ * exp
+  | ImportE of path
 
 and bind = (bind', unit) phrase
 and bind' =
@@ -375,6 +377,7 @@ let label_of_exp e =
   | UnwrapE _ -> "UnwrapE"
   | UnrollE _ -> "UnrollE"
   | RecE _ -> "RecE"
+  | ImportE _ -> "ImportE"
 
 let label_of_bind b =
   match b.it with
@@ -433,6 +436,7 @@ and string_of_exp e =
   | UnwrapE(x, t) -> node' [string_of_var x; string_of_typ t]
   | UnrollE(x, t) -> node' [string_of_var x; string_of_typ t]
   | RecE(x, t, e) -> node' [string_of_var x; string_of_typ t; string_of_exp e]
+  | ImportE(p) -> node' ["\"" ^ String.escaped p.it ^ "\""]
 
 and string_of_bind b =
   let node' = node (label_of_bind b) in
@@ -442,3 +446,50 @@ and string_of_bind b =
   | VarB(x, e) -> node' [string_of_var x; string_of_exp e]
   | InclB(e) -> node' [string_of_exp e]
   | TypeErrorB(e) -> node' [string_of_exp e]
+
+(* Import *)
+
+let rec imports_typ typ =
+  match typ.it with
+  | PathT exp -> imports_exp exp
+  | PrimT _ -> []
+  | TypT -> []
+  | HoleT -> []
+  | StrT dec -> imports_dec dec
+  | FunT(_, typ1, typ2, _, _) -> imports_typ typ1 @ imports_typ typ2
+  | WrapT typ -> imports_typ typ
+  | EqT exp -> imports_exp exp
+  | AsT(typ1, typ2) -> imports_typ typ1 @ imports_typ typ2
+  | WithT(typ, _, exp) -> imports_typ typ @ imports_exp exp
+
+and imports_dec dec =
+  match dec.it with
+  | EmptyD -> []
+  | SeqD(dec1, dec2) -> imports_dec dec1 @ imports_dec dec2
+  | VarD(_, typ) -> imports_typ typ
+  | InclD typ -> imports_typ typ
+
+and imports_exp exp =
+  match exp.it with
+  | VarE _ -> []
+  | PrimE _ -> []
+  | TypE typ -> imports_typ typ
+  | StrE bind -> imports_bind bind
+  | FunE(_, typ, exp, _) -> imports_typ typ @ imports_exp exp
+  | WrapE(_, typ) -> imports_typ typ
+  | RollE(_, typ) -> imports_typ typ
+  | IfE(_, exp1, exp2, typ) -> imports_exp exp1 @ imports_exp exp2 @ imports_typ typ
+  | DotE(exp, _) -> imports_exp exp
+  | AppE _ -> []
+  | UnwrapE(_, typ) -> imports_typ typ
+  | UnrollE(_, typ) -> imports_typ typ
+  | RecE(_, typ, exp) -> imports_typ typ @ imports_exp exp
+  | ImportE path -> [path]
+
+and imports_bind bind =
+  match bind.it with
+  | EmptyB -> []
+  | SeqB(bind1, bind2) -> imports_bind bind1 @ imports_bind bind2
+  | VarB(_, exp) -> imports_exp exp
+  | InclB exp -> imports_exp exp
+  | TypeErrorB exp -> imports_exp exp

--- a/talk.1ml
+++ b/talk.1ml
@@ -1,3 +1,5 @@
+local import "prelude.1ml"
+
 ;; Types as modules
 
 M1 = {type t = int} : {type t = int} :> {type t}

--- a/travis.sh
+++ b/travis.sh
@@ -32,5 +32,5 @@ fi
 folded "Build 1ML" make
 
 for f in *.1ml; do
-  folded "$f" ./1ml -c prelude.1ml "$f"
+  folded "$f" ./1ml -c "$f"
 done


### PR DESCRIPTION
An `import "path"` expression "statically" loads the module implemented in the file "path".  `import` expressions are hoisted out of their containing module expression and the referenced files are then evaluated once and their results are bound to variables.  An `import` expression is then interpreted as a reference to a variable.

An `import "path"` binding is sugar for `...import "path"`.