### PR TITLE
Change to use `->` for pure and `~>` for impure function types

### DIFF
--- a/basis/index.1ml
+++ b/basis/index.1ml
@@ -6,7 +6,7 @@ List = import "./list"
 
 type ORD = {
   type t
-  (<=) : t => t -> Bool.t
+  (<=) : t -> t ~> Bool.t
 }
 
 type SET = {
@@ -14,15 +14,15 @@ type SET = {
   type elem
   type t = set
   empty : set
-  add : elem -> set -> set
-  mem : elem -> set -> bool
-  card : set -> int
+  add : elem -> set ~> set
+  mem : elem -> set ~> bool
+  card : set ~> int
 }
 
 Set (Elem : ORD) :> SET with (elem = Elem.t) = {
   type elem = Elem.t
   x == y = let ...Elem in (x <= y) && (y <= x)
-  type set = (int, elem -> bool)
+  type set = (int, elem ~> bool)
   type t = set
   empty = (0, fun (x : elem) => false)
   card (s : set) = s._1
@@ -40,14 +40,14 @@ type MAP = {
   type key
   type t a = map a
   empty 'a : map a
-  add 'a : key -> a -> map a -> map a
-  lookup 'a : key -> map a -> opt a
+  add 'a : key -> a -> map a ~> map a
+  lookup 'a : key -> map a ~> opt a
 }
 
 Map (Key : ORD) :> MAP with (key = Key.t) = {
   type key = Key.t
   x == y = let ...Key in (x <= y) && (y <= x)
-  type map a = key -> opt a
+  type map a = key ~> opt a
   t = map
   empty x = none
   lookup x m = m x

--- a/basis/list.1ml
+++ b/basis/list.1ml
@@ -9,14 +9,14 @@ tail = case {nil = none, _::xs = some xs}
 
 foldr (::) nil = rec loop => case {nil, x::xs = x::loop xs}
 
-foldl xss = rec (loop: _ => _) => fun s => case {
+foldl xss = rec (loop: _ -> _) => fun s => case {
   nil = s
   x :: xs = loop (xss x s) xs
 }
 
 length = foldl (const 1 >> (+)) 0
 
-nth = rec (loop: _ => _) => fun n => case {
+nth = rec (loop: _ -> _) => fun n => case {
   nil = none
   x :: xs = if n == 0 then some x else loop (n-1) xs
 }

--- a/lexer.mll
+++ b/lexer.mll
@@ -244,6 +244,7 @@ rule token = parse
   | ":" { COLON }
   | ":>" { SEAL }
   | "->" { ARROW }
+  | "~>" { SARROW }
   | "=>" { DARROW }
   | "." { DOT }
   | "'" { TICK }

--- a/paper.1ml
+++ b/paper.1ml
@@ -32,12 +32,12 @@ M = {
 
 M_opaque = M : {
   size : type
-  pair : (a : type) => (b : type) => type
+  pair : (a : type) -> (b : type) -> type
 }
 
 M_transparent = M : {
   size : (= type int)
-  pair : (a : type) => (b : type) => (= type {fst : a, snd : b})
+  pair : (a : type) -> (b : type) -> (= type {fst : a, snd : b})
 }
 
 M_opaque = M : {
@@ -54,20 +54,20 @@ M_transparent = M : {
 
 type EQ = {
   type t
-  eq : t -> t -> bool
+  eq : t -> t ~> bool
 }
 
 type MAP = {
   type key
   type map a
   empty (a : type) : map a
-  add (a : type) : key -> a -> map a -> map a
-  lookup (a : type) : key -> map a -> opt a
+  add (a : type) : key -> a -> map a ~> map a
+  lookup (a : type) : key -> map a ~> opt a
 }
 
 Map (Key : EQ) :> MAP with (type key = Key.t) = {
   type key = Key.t
-  type map a = key -> opt a
+  type map a = key ~> opt a
   empty (a : type) = fun (k : key) => none
   lookup (a : type) (k : key) (m : map a) = m k
   add (a : type) (k : key) (v : a) (m : map a) =
@@ -76,16 +76,16 @@ Map (Key : EQ) :> MAP with (type key = Key.t) = {
 
 ;; Applicative vs. Generative
 
-F = (fun (a : type) => type {x : a}) :> type => type
-G = (fun (a : type) => type {x : a}) :> type -> type
+F = (fun (a : type) => type {x : a}) :> type -> type
+G = (fun (a : type) => type {x : a}) :> type ~> type
 H = fun (a : type) => (type {x : a} :> type)
-type_error G :> type => type
+type_error G :> type -> type
 
 ;; Higher Polymorphism
 
-f (id : (a : type) => a -> a) = {x = id int 5, y = id bool true}
+f (id : (a : type) -> a ~> a) = {x = id int 5, y = id bool true}
 
-type SHAPE = {type t, area : t -> int, v : t}
+type SHAPE = {type t, area : t ~> int, v : t}
 volume (height : int) (s : SHAPE) = height * s.area s.v
 area ss = List.foldl ss 0 (fun a (wrap s : wrap SHAPE) => a + s.area s.v)
 
@@ -93,26 +93,26 @@ type COLL c = {
   type key
   type val
   empty : c
-  add : c -> key -> val -> c
-  lookup : c -> key -> opt val
-  keys : c -> list key
+  add : c -> key -> val ~> c
+  lookup : c -> key ~> opt val
+  keys : c ~> list key
 }
 entries (c : type) (C : COLL c) (xs : c) : list (type (C.key, C.val)) =
   List.map (C.keys xs) (fun (k : C.key) => (k, caseopt (C.lookup xs k) bot id))
 
-type MONAD (m : type => type) = {
-  return (a : type) : a -> m a
-  bind (a : type) (b : type) : m a -> (a -> m b) -> m b
+type MONAD (m : type -> type) = {
+  return (a : type) : a ~> m a
+  bind (a : type) (b : type) : m a -> (a ~> m b) ~> m b
 }
-map (a : type) (b : type) (m : type => type) (M : MONAD m) (f : a -> b) (mx : m a) =
+map (a : type) (b : type) (m : type -> type) (M : MONAD m) (f : a ~> b) (mx : m a) =
   M.bind a b mx (fun (x : a) => M.return b (f x))  ;; : m b
 
 ;; ...the same with implicit types:
-type MONAD (m : type => type) = {
-  return 'a : a -> m a
-  bind 'a 'b : m a -> (a -> m b) -> m b
+type MONAD (m : type -> type) = {
+  return 'a : a ~> m a
+  bind 'a 'b : m a -> (a ~> m b) ~> m b
 }
-map (m : type => type) (M : MONAD m) f mx =
+map (m : type -> type) (M : MONAD m) f mx =
   M.bind mx (fun x => M.return (f x))
 
 ;; Computed Modules
@@ -124,24 +124,24 @@ pickTable (size : int) (threshold : int) (HashMap : MAP) (TreeMap : MAP) = {
 (;
 type MONAD = {
   type t a
-  return (a : type) : a -> t a
-  bind (a : type) (b : type) : t a -> (a -> t b) -> t b
+  return (a : type) : a ~> t a
+  bind (a : type) (b : type) : t a -> (a ~> t b) ~> t b
 }
 type MONAD_TRANS = {
   ... MONAD
   type base a
-  lift (a : type) : base a -> t a
-  join (a : type) : t (base a) -> t a
+  lift (a : type) : base a ~> t a
+  join (a : type) : t (base a) ~> t a
 }
 
-mapM (M : MONAD) (a : type) (b : type) (f : a -> b) (m : M.t a) : M.t b =
+mapM (M : MONAD) (a : type) (b : type) (f : a ~> b) (m : M.t a) : M.t b =
   M.bind a b m (fun (x : a) => M.return b (f x))
 
 joinM (M : MONAD) (a : type) (mm : M.t (M.t a)) : M.t a =
   M.bind (M.t a) a mm (fun (m : M.t a) => m)
 
 StackM (M : MONAD) =
-  rec (Loop : (n : int) -> (MONAD_TRANS with (base = M.t))) =>
+  rec (Loop : (n : int) ~> (MONAD_TRANS with (base = M.t))) =>
   fun (n : int) =>
   if n == 1 then
     { ... M
@@ -157,7 +157,7 @@ StackM (M : MONAD) =
       lift (a : type) (m : base a) = M'.return (M.t a) m
       join (a : type) (m : t (base a)) = M'.join (base a) m
       return (a : type) (x : a) = M'.return (M.t a) (M.return a x)
-      bind (a : type) (b : type) (m : t a) (f : a -> t b) =
+      bind (a : type) (b : type) (m : t a) (f : a ~> t b) =
         M'.bind (M.t a) (M.t b) m
           (fun (mx : M.t a) => M.bind a b mx
             (fun (x : a) => f x))
@@ -170,8 +170,8 @@ StackM (M : MONAD) =
 type T1 = type
 type T2 = {type u}
 type T3 = {type u = T2}
-type T4 = (x : {}) -> type
-type T5 = (a : type) => {}
+type T4 = (x : {}) ~> type
+type T5 = (a : type) -> {}
 type T6 = {type u a = bool}
 
 type Ti = T1
@@ -203,26 +203,26 @@ type_error { Test (X : MONSTER) = X : MONSTER }
 ;; Section 4: Full 1ML
 
 SubtypingImplicitsWithTypeMatching =
-  fun (X : '(a : type) => {type t = a, f : a -> t}) =>
-       X : {type t, f : int -> int}
+  fun (X : '(a : type) -> {type t = a, f : a ~> t}) =>
+       X : {type t, f : int ~> int}
 
 type MAP = {
   type key
   type map a
   empty 'a : map a
-  lookup 'a : key -> map a -> opt a
-  add 'a : key -> a -> map a -> map a
+  lookup 'a : key -> map a ~> opt a
+  add 'a : key -> a -> map a ~> map a
 }
 Map (Key : EQ) :> MAP with (type key = Key.t) = {
   type key = Key.t
-  type map a = key -> opt a
+  type map a = key ~> opt a
   empty = fun x => none
   lookup x m = m x
   add x y m = fun z => if Key.eq z x then some y else m z
 }
 
 FirstClassImplicit =
-  (fun (id : 'a  => a -> a) => {x = id 3, y = id true}) (fun x => x)
+  (fun (id : 'a -> a -> a) => {x = id 3, y = id true}) (fun x => x)
 
 
 ;; Section 5: Inference
@@ -230,7 +230,7 @@ FirstClassImplicit =
 
 ;; Type Scoping
 
-id : 'a => a -> a = fun x => x
+id : 'a -> a ~> a = fun x => x
 G (x : int) = {M = {type t = int, v = x} :> {type t, v : t}, f = id id}
 C = G 3
 type_error C.f C.M.v
@@ -242,13 +242,13 @@ C = G 3
 x = C.f C.M.v
 
 ;; ...or with type annotation:
-id : 'a => a -> a = fun x => x
-G (x : int) = {M = {type t = int, v = x} :> {type t, v : t}, f : M.t -> M.t = id id}
+id : 'a -> a ~> a = fun x => x
+G (x : int) = {M = {type t = int, v = x} :> {type t, v : t}, f : M.t ~> M.t = id id}
 C = G 3
 x = C.f C.M.v
 
 ;; ...or when applying G twice.
-id : 'a => a -> a = fun x => x
+id : 'a -> a ~> a = fun x => x
 G (x : int) = {M = {type t = int, v = x} :> {type t, v : t}, f = id id}
 C = G 3
 C' = G 3
@@ -262,11 +262,11 @@ type OPT = {
   type opt a
   none 'a : opt a
   some 'a : a -> opt a
-  caseopt 'a 'b : opt a -> b -> (a -> b) -> b
+  caseopt 'a 'b : opt a -> b -> (a ~> b) ~> b
 }
 Opt :> OPT = {
-  type opt a = wrap (b : type) => b -> (a -> b) -> b
-  none 'a = wrap (fun (b : type) (n : b) (s : a -> b) => n) : opt a
-  some 'a x = wrap (fun (b : type) (n : b) (s : a -> b) => s x) : opt a
+  type opt a = wrap (b : type) -> b -> (a ~> b) ~> b
+  none 'a = wrap (fun (b : type) (n : b) (s : a ~> b) => n) : opt a
+  some 'a x = wrap (fun (b : type) (n : b) (s : a ~> b) => s x) : opt a
   caseopt 'a 'b xo = (unwrap xo : opt a) b
 }

--- a/parser.mly
+++ b/parser.mly
@@ -28,7 +28,7 @@ let parse_error s = raise (Source.Error (Source.nowhere_region, s))
 %token HOLE PRIMITIVE
 %token FUN REC LET IN DO WRAP UNWRAP TYPE ELLIPSIS
 %token IF THEN ELSE LOGICAL_OR LOGICAL_AND AS
-%token EQUAL COLON SEAL ARROW DARROW
+%token EQUAL COLON SEAL ARROW SARROW DARROW
 %token WITH
 %token LPAR RPAR
 %token LBRACE RBRACE
@@ -159,9 +159,9 @@ oneexplparam :
     { [$1] }
 ;
 arrow :
-  | ARROW
+  | SARROW
     { Impure@@at() }
-  | DARROW
+  | ARROW
     { Pure@@at() }
 ;
 

--- a/prelude.1ml
+++ b/prelude.1ml
@@ -108,12 +108,12 @@ type OPT = {
   type opt a
   none 'a : opt a
   some 'a : a -> opt a
-  caseopt 'a 'b : opt a -> (() -> b) -> (a -> b) -> b
+  caseopt 'a 'b : opt a -> (() ~> b) -> (a ~> b) ~> b
 }
 Opt :> OPT = {
-  type opt a = wrap (b : type) => (() -> b) -> (a -> b) -> b
-  none 'a = wrap (fun (b : type) (n : () -> b) (s : a -> b) => n ()) : opt a
-  some 'a x = wrap (fun (b : type) (n : () -> b) (s : a -> b) => s x) : opt a
+  type opt a = wrap (b : type) -> (() ~> b) -> (a ~> b) ~> b
+  none 'a = wrap (fun (b : type) (n : () ~> b) (s : a ~> b) => n ()) : opt a
+  some 'a x = wrap (fun (b : type) (n : () ~> b) (s : a ~> b) => s x) : opt a
   caseopt xo = (unwrap xo : opt _) _
 }
 ...Opt
@@ -125,14 +125,14 @@ type ALT = {
   type alt a b
   left 'a 'b : a -> alt a b
   right 'a 'b : b -> alt a b
-  casealt 'a 'b 'c : alt a b -> (a -> c) -> (b -> c) -> c
+  casealt 'a 'b 'c : alt a b -> (a ~> c) -> (b ~> c) ~> c
 }
 Alt :> ALT = {
-  type alt a b = wrap (c : type) => (a -> c) -> (b -> c) -> c
+  type alt a b = wrap (c : type) -> (a ~> c) -> (b ~> c) ~> c
   left 'a 'b x =
-    wrap (fun (c : type) (l : a -> c) (r : b -> c) => l x) : alt a b
+    wrap (fun (c : type) (l : a ~> c) (r : b ~> c) => l x) : alt a b
   right 'a 'b x =
-    wrap (fun (c : type) (l : a -> c) (r : b -> c) => r x) : alt a b
+    wrap (fun (c : type) (l : a ~> c) (r : b ~> c) => r x) : alt a b
   casealt xy = (unwrap xy : alt _ _) _
 }
 ...Alt
@@ -144,28 +144,28 @@ type LIST_CORE = {
   type list a
   nil 'a : list a
   cons 'a : a -> list a -> list a
-  foldr 'a 'b : list a -> b -> (a -> b -> b) -> b
+  foldr 'a 'b : list a -> b -> (a ~> b ~> b) ~> b
 }
 type LIST = {
   ...LIST_CORE
-  caselist 'a 'b : list a -> (() -> b) -> (a -> list a -> b) -> b
-  isNil 'a : list a -> bool
-  head 'a : list a -> opt a
-  tail 'a : list a -> opt (list a)
-  length 'a : list a -> int
-  cat 'a : list a -> list a -> list a
-  rev 'a : list a -> list a
-  nth 'a : list a -> int -> opt a
-  map 'a 'b : list a -> (a -> b) -> list b
-  filter 'a : list a -> (a -> bool) -> list a
-  foldl 'a 'b : list a -> b -> (b -> a -> b) -> b
+  caselist 'a 'b : list a -> (() ~> b) -> (a ~> list a ~> b) ~> b
+  isNil 'a : list a ~> bool
+  head 'a : list a ~> opt a
+  tail 'a : list a ~> opt (list a)
+  length 'a : list a ~> int
+  cat 'a : list a -> list a ~> list a
+  rev 'a : list a ~> list a
+  nth 'a : list a -> int ~> opt a
+  map 'a 'b : list a -> (a ~> b) ~> list b
+  filter 'a : list a -> (a ~> bool) ~> list a
+  foldl 'a 'b : list a -> b -> (b ~> a ~> b) ~> b
 }
 List :> LIST = {
   ...{
-    type list a = wrap (b : type) => b -> (a -> b -> b) -> b
-    nil 'a = wrap (fun (b : type) (n : b) (c : a -> b -> b) => n) : list _
+    type list a = wrap (b : type) -> b -> (a ~> b ~> b) ~> b
+    nil 'a = wrap (fun (b : type) (n : b) (c : a ~> b ~> b) => n) : list _
     cons x xs =
-      wrap (fun (b : type) (n : b) (c : _ -> b -> b) =>
+      wrap (fun (b : type) (n : b) (c : _ ~> b ~> b) =>
         c x ((unwrap xs : list _) b n c)) : list _
     foldr xs = (unwrap xs : list _) _
   } :> LIST_CORE
@@ -195,7 +195,7 @@ List :> LIST = {
 
 type ORD = {
   type t
-  (<=) : t => t -> bool
+  (<=) : t -> t ~> bool
 }
 
 type SET = {
@@ -203,15 +203,15 @@ type SET = {
   type elem
   type t = set
   empty : set
-  add : elem -> set -> set
-  mem : elem -> set -> bool
+  add : elem -> set ~> set
+  mem : elem -> set ~> bool
   card : set -> int
 }
 
 Set (Elem : ORD) :> SET with (elem = Elem.t) = {
   type elem = Elem.t
   x == y = let ...Elem in (x <= y) && (y <= x)
-  type set = (int, elem -> bool)
+  type set = (int, elem ~> bool)
   type t = set
   empty = (0, fun (x : elem) => false)
   card (s : set) = s._1
@@ -229,14 +229,14 @@ type MAP = {
   type key
   type t a = map a
   empty 'a : map a
-  add 'a : key -> a -> map a -> map a
-  lookup 'a : key -> map a -> opt a
+  add 'a : key -> a -> map a ~> map a
+  lookup 'a : key -> map a ~> opt a
 }
 
 Map (Key : ORD) :> MAP with (key = Key.t) = {
   type key = Key.t
   x == y = let ...Key in (x <= y) && (y <= x)
-  type map a = key -> opt a
+  type map a = key ~> opt a
   t = map
   empty x = none
   lookup x m = m x

--- a/prelude/index.1ml
+++ b/prelude/index.1ml
@@ -11,10 +11,10 @@ Bool = {
 ;;
 
 Fun = {
-  type t a b = a -> b
+  type t a b = a ~> b
   id x = x
   const x _ = x
-  bot = rec (bot: _ => _) => fun x => bot x
+  bot = rec (bot: _ -> _) => fun x => bot x
   curry f x y = f (x, y)
   uncurry f (x, y) = f x y
   flip f x y = f y x
@@ -28,11 +28,11 @@ Fun = {
 
 Alt :> {
   type t _ _
-  inl 'a 'b: a => t a b
-  inr 'a 'b: b => t a b
-  case 'a 'b 'o: {inl: a -> o, inr: b -> o} => t a b -> o
+  inl 'a 'b: a -> t a b
+  inr 'a 'b: b -> t a b
+  case 'a 'b 'o: {inl: a ~> o, inr: b ~> o} -> t a b ~> o
 } = {
-  type t a b = wrap 'o => {inl: a -> o, inr: b -> o} -> o
+  type t a b = wrap 'o -> {inl: a ~> o, inr: b ~> o} ~> o
   inl x = wrap (fun c => c.inl x): t _ _
   inr x = wrap (fun c => c.inr x): t _ _
   case c (wrap x: t _ _) = x c

--- a/prelude/index.1mls
+++ b/prelude/index.1mls
@@ -8,69 +8,69 @@ local
 
 Alt: {
   type t _ _
-  inl 'a 'b: a => t a b
-  inr 'a 'b: b => t a b
-  case 'a 'b 'o: {inl: a -> o, inr: b -> o} => t a b -> o
-  either 'a 'b 'o: (a -> o) => (b -> o) => t a b -> o
-  plus 'a 'b 'c 'd: (a -> c) => (b -> d) => t a b -> t c d
+  inl 'a 'b: a -> t a b
+  inr 'a 'b: b -> t a b
+  case 'a 'b 'o: {inl: a ~> o, inr: b ~> o} -> t a b ~> o
+  either 'a 'b 'o: (a ~> o) -> (b ~> o) -> t a b ~> o
+  plus 'a 'b 'c 'd: (a ~> c) -> (b ~> d) -> t a b ~> t c d
 }
 
 ;;
 
 Bool: {
   type t = bool
-  (==): t => t => bool
-  (<>): t => t => bool
+  (==): t -> t -> bool
+  (<>): t -> t -> bool
   true: t
   false: t
-  not: t => t
-  toText: t => text
+  not: t -> t
+  toText: t -> text
 }
 
 ;;
 
 Char: {
   type t = char
-  (==): t => t => bool
-  (<>): t => t => bool
-  toInt: t => int
-  fromInt: int => t
-  print: t -> {}
+  (==): t -> t -> bool
+  (<>): t -> t -> bool
+  toInt: t -> int
+  fromInt: int -> t
+  print: t ~> {}
 }
 
 ;;
 
 Fun: {
-  type t a b = a -> b
-  id 'a: a => a
-  const 'a 'b: a => b => a
-  bot 'a 'b: a => b
-  curry 'a 'b 'c: ((a, b) -> c) => a => b -> c
-  uncurry 'a 'b 'c: (a -> b -> c) => (a, b) -> c
-  flip 'a 'b 'c: (a -> b -> c) => b => a -> c
-  (<<) 'a 'b 'c: (b -> c) => (a -> b) => a -> c
-  (>>) 'a 'b 'c: (a -> b) => (b -> c) => a -> c
-  (<|) 'a 'b: (a -> b) => a -> b
-  (|>) 'a 'b: a => (a -> b) -> b
+  type t a b = a ~> b
+  id 'a: a -> a
+  const 'a 'b: a -> b -> a
+  bot 'a 'b: a -> b
+  curry 'a 'b 'c: ((a, b) ~> c) -> a -> b ~> c
+  uncurry 'a 'b 'c: (a ~> b ~> c) -> (a, b) ~> c
+  flip 'a 'b 'c: (a ~> b ~> c) -> b -> a ~> c
+  (<<) 'a 'b 'c: (b ~> c) -> (a ~> b) -> a ~> c
+  (>>) 'a 'b 'c: (a ~> b) -> (b ~> c) -> a ~> c
+  (<|) 'a 'b: (a ~> b) -> a ~> b
+  (|>) 'a 'b: a -> (a ~> b) ~> b
 }
 
 ;;
 
 Int: {
   type t = int
-  (==): t => t => bool
-  (<>): t => t => bool
-  (<): t => t => bool
-  (>): t => t => bool
-  (<=): t => t => bool
-  (>=): t => t => bool
-  (+): t => t => t
-  (-): t => t => t
-  (*): t => t => t
-  (/): t => t => t
-  (%): t => t => t
-  toText: t => text
-  print: t -> {}
+  (==): t -> t -> bool
+  (<>): t -> t -> bool
+  (<): t -> t -> bool
+  (>): t -> t -> bool
+  (<=): t -> t -> bool
+  (>=): t -> t -> bool
+  (+): t -> t -> t
+  (-): t -> t -> t
+  (*): t -> t -> t
+  (/): t -> t -> t
+  (%): t -> t -> t
+  toText: t -> text
+  print: t ~> {}
 }
 
 ;;
@@ -78,8 +78,8 @@ Int: {
 List: {
   type t _
   nil 'a: t a
-  (::) 'a: a => t a => t a
-  case 'a 'o: {nil: o, (::): a -> t a -> o} => t a -> o
+  (::) 'a: a -> t a -> t a
+  case 'a 'o: {nil: o, (::): a ~> t a ~> o} -> t a ~> o
 }
 
 ;;
@@ -87,35 +87,35 @@ List: {
 Opt: {
   type t _
   none 'a: t a
-  some 'a: a => t a
-  case 'a 'o: {none: o, some: a -> o} => t a -> o
+  some 'a: a -> t a
+  case 'a 'o: {none: o, some: a ~> o} -> t a ~> o
 }
 
 ;;
 
 Pair: {
   type t a b = (a, b)
-  fst 'a 'b: (a, b) => a
-  snd 'a 'b: (a, b) => b
-  cross 'a 'b 'c 'd: (a -> c) => (b -> d) => (a, b) -> (c, d)
-  fork 'a 'b 'c: (a -> b) => (a -> c) => a -> (b, c)
+  fst 'a 'b: (a, b) -> a
+  snd 'a 'b: (a, b) -> b
+  cross 'a 'b 'c 'd: (a ~> c) -> (b ~> d) -> (a, b) ~> (c, d)
+  fork 'a 'b 'c: (a ~> b) -> (a ~> c) -> a ~> (b, c)
 }
 
 ;;
 
 Text: {
   type t = text
-  (==): t => t => bool
-  (<>): t => t => bool
-  (<): t => t => bool
-  (>): t => t => bool
-  (<=): t => t => bool
-  (>=): t => t => bool
-  (++): t => t => t
-  length: t => int
-  sub: t => int => char
-  fromChar: char => t
-  print: t -> {}
+  (==): t -> t -> bool
+  (<>): t -> t -> bool
+  (<): t -> t -> bool
+  (>): t -> t -> bool
+  (<=): t -> t -> bool
+  (>=): t -> t -> bool
+  (++): t -> t -> t
+  length: t -> int
+  sub: t -> int -> char
+  fromChar: char -> t
+  print: t ~> {}
 }
 
 ;;
@@ -130,41 +130,41 @@ type text = Text.t
 
 ;;
 
-(%): int => int => int
-(*): int => int => int
-(+): int => int => int
-(++): text => text => text
-(-): int => int => int
-(/): int => int => int
-(::) 'a: a => list a => list a
-(<): int => int => bool
-(<<) 'a 'b 'c: (b -> c) => (a -> b) => a -> c
-(<=): int => int => bool
-(<>): int => int => bool
-(<|) 'a 'b: (a -> b) => a -> b
-(==): int => int => bool
-(>): int => int => bool
-(>=): int => int => bool
-(>>) 'a 'b 'c: (a -> b) => (b -> c) => a -> c
-(|>) 'a 'b: a => (a -> b) -> b
-bot 'a 'b: a => b
-const 'a 'b: a => b => a
-cross 'a 'b 'c 'd: (a -> c) => (b -> d) => (a, b) -> (c, d)
-curry 'a 'b 'c: ((a, b) -> c) => a => b -> c
-either 'a 'b 'o: (a -> o) => (b -> o) => alt a b -> o
+(%): int -> int -> int
+(*): int -> int -> int
+(+): int -> int -> int
+(++): text -> text -> text
+(-): int -> int -> int
+(/): int -> int -> int
+(::) 'a: a -> list a -> list a
+(<): int -> int -> bool
+(<<) 'a 'b 'c: (b ~> c) -> (a ~> b) -> a ~> c
+(<=): int -> int -> bool
+(<>): int -> int -> bool
+(<|) 'a 'b: (a ~> b) -> a ~> b
+(==): int -> int -> bool
+(>): int -> int -> bool
+(>=): int -> int -> bool
+(>>) 'a 'b 'c: (a ~> b) -> (b ~> c) -> a ~> c
+(|>) 'a 'b: a -> (a ~> b) ~> b
+bot 'a 'b: a -> b
+const 'a 'b: a -> b -> a
+cross 'a 'b 'c 'd: (a ~> c) -> (b ~> d) -> (a, b) ~> (c, d)
+curry 'a 'b 'c: ((a, b) ~> c) -> a -> b ~> c
+either 'a 'b 'o: (a ~> o) -> (b ~> o) -> alt a b ~> o
 false: bool
-flip 'a 'b 'c: (a -> b -> c) => b => a -> c
-fork 'a 'b 'c: (a -> b) => (a -> c) => a -> (b, c)
-fst 'a 'b: (a, b) => a
-id 'a: a => a
-inl 'a 'b: a => alt a b
-inr 'a 'b: b => alt a b
+flip 'a 'b 'c: (a ~> b ~> c) -> b -> a ~> c
+fork 'a 'b 'c: (a ~> b) -> (a ~> c) -> a ~> (b, c)
+fst 'a 'b: (a, b) -> a
+id 'a: a -> a
+inl 'a 'b: a -> alt a b
+inr 'a 'b: b -> alt a b
 nil 'a: list a
 none 'a: opt a
-not: bool => bool
-plus 'a 'b 'c 'd: (a -> c) => (b -> d) => alt a b -> alt c d
-print: text -> {}
-snd 'a 'b: (a, b) => b
-some 'a: a => opt a
+not: bool -> bool
+plus 'a 'b 'c 'd: (a ~> c) -> (b ~> d) -> alt a b ~> alt c d
+print: text ~> {}
+snd 'a 'b: (a, b) -> b
+some 'a: a -> opt a
 true: bool
-uncurry 'a 'b 'c: (a -> b -> c) => (a, b) -> c
+uncurry 'a 'b 'c: (a ~> b ~> c) -> (a, b) ~> c

--- a/regression.1ml
+++ b/regression.1ml
@@ -13,15 +13,15 @@ type DEC_PUNNING = {int, list}
 Equivalence: {
   type t a b
 
-  transitivity 'a 'b 'c: t a b => t b c -> t a c
+  transitivity 'a 'b 'c: t a b -> t b c -> t a c
   reflexivity 'a: t a a
 
   symmetry 'a 'b: t a b -> t b a
 
-  to   'a 'b: t a b => a -> b
-  from 'a 'b: t a b => b -> a
+  to   'a 'b: t a b -> a ~> b
+  from 'a 'b: t a b -> b ~> a
 } = {
-  type T a b = (type p _) -> p a -> p b
+  type T a b = (type p _) ~> p a ~> p b
   type t a b = wrap T a b
   wr (eq: T _ _) = wrap eq: t _ _
   un eq = unwrap eq: t _ _
@@ -29,9 +29,9 @@ Equivalence: {
     wr (fun (type p _) => un bc p << un ab p)
   reflexivity = wr (fun (type p _) => id)
   to eq a = un eq (fun (type x) => x) a
-  from 'a 'b (eq: t a b) b = un eq (fun (type b) => type b -> a) id b
+  from 'a 'b (eq: t a b) b = un eq (fun (type b) => type b ~> a) id b
   symmetry 'a 'b (eq: t a b) : t b a =
-    wr (fun (type p _) => un eq (fun (type b) => type p b -> p a) id)
+    wr (fun (type p _) => un eq (fun (type b) => type p b ~> p a) id)
 }
 
 ;;
@@ -65,7 +65,7 @@ seq_exps x : (_, _) =
 
 hole_is_allowed_type_pattern (type _ _) = ()
 
-typparams_allowed (id 'a: a => a) ({alsoId 'x: x => x}) =
+typparams_allowed (id 'a: a -> a) ({alsoId 'x: x -> x}) =
   alsoId (id 1, id "one", alsoId true)
 
 ;;
@@ -85,21 +85,21 @@ type_error { type_error 101 }
 ;;
 
 type_error {
-  Impure : () => {type t} = fun () =>
+  Impure : () -> {type t} = fun () =>
     if true then {type t = int} else {type t = bool} : {type t}
 }
 
-ImpureIf : () -> {type t} = fun () =>
+ImpureIf : () ~> {type t} = fun () =>
   if true then {type t = int} else {type t = bool} : {type t}
 
-PureIf : () => ('a => a => a) = fun () =>
-  if true then id else id : 'a => a => a
+PureIf : () -> ('a -> a -> a) = fun () =>
+  if true then id else id : 'a -> a -> a
 
-Pure : () => {type t = bool, existentials: t} = fun () =>
+Pure : () -> {type t = bool, existentials: t} = fun () =>
   {type t = bool, existentials = false} :> {type t = bool, existentials: t}
 
 type_error {
-  Impure : () => {type t, existentials: t} = fun () =>
+  Impure : () -> {type t, existentials: t} = fun () =>
     {type t = bool, existentials = true} :> {type t = bool, existentials: t}
 }
 
@@ -109,7 +109,7 @@ type_error rec (R: {}) => {
   kaboom () = R
 }
 
-Kaboom = rec (R: rec R => {kaboom: () -> R}) => @(= R) {
+Kaboom = rec (R: rec R => {kaboom: () ~> R}) => @(= R) {
   kaboom () = R
 }
 
@@ -130,10 +130,10 @@ Mutually = let
 in {
   ...rec (R: {
     Even: {
-      size 'x: T.Even.t x -> int
+      size 'x: T.Even.t x ~> int
     }
     Odd: {
-      size 'x: T.Odd.t x -> int
+      size 'x: T.Odd.t x ~> int
     }
   }) => {
     Even = {
@@ -170,14 +170,14 @@ Alt = {
 infix_type_pat 'a 'b (type _ | _) (x: a | b) = x
 infix_type_dec 'a 'b ({type _ | _}) (x: a | b) = x
 
-type infix_tycon_param a b = (type _ <+> _) => a <+> b
+type infix_tycon_param a b = (type _ <+> _) -> a <+> b
 
 type (a `>>` b) c = c
 
 ;;
 
 Hungry = {
-  type eat a = rec eat_a => a -> eat_a
+  type eat a = rec eat_a => a ~> eat_a
 
   eater 'a: eat a = rec (eater: eat a) => @(eat a) (fun a => eater)
 
@@ -208,9 +208,9 @@ N :> {
 ListN = let
   type I (type x) (type p _) (type t _ _) = {
     nil     :               p N.Z
-    (::) 'n : x -> t x n -> p (N.S n)
+    (::) 'n : x ~> t x n ~> p (N.S n)
   }
-  type T x n (type t _ _) = (type p _) => I x p t -> p n
+  type T x n (type t _ _) = (type p _) -> I x p t ~> p n
 in {
   ...rec {type t _ _} => {type t x n = wrap T x n t}
 
@@ -224,15 +224,15 @@ in {
 } :> {
   type t _ _
 
-  case 'x 'n: (type p _) => I x p t => t x n -> p n
+  case 'x 'n: (type p _) -> I x p t -> t x n ~> p n
 
   nil  'x    :               t x N.Z
-  (::) 'x 'n : x => t x n => t x (N.S n)
+  (::) 'x 'n : x -> t x n -> t x (N.S n)
 }
 
 ListN = {
   ...ListN
-  map 'x 'y (xy: x -> y) = rec (map 'n: t x n -> t y n) =>
+  map 'x 'y (xy: x ~> y) = rec (map 'n: t x n ~> t y n) =>
     case (t _) {
       nil
       x :: xs = xy x :: map xs

--- a/russo.1ml
+++ b/russo.1ml
@@ -30,10 +30,10 @@ ArraySucc (A : ARRAY) = {
     else (a.1, A.update a.2 (i / 2) x)
 }
 
-MkArray = rec (mkArray : int -> ARRAY) => fun n =>
+MkArray = rec (mkArray : int ~> ARRAY) => fun n =>
   if n == 0 then ArrayZero else ArraySucc (mkArray (n - 1)) : ARRAY
 
-printArray 't (A : ARRAY) (pr : t -> ()) a =
+printArray 't (A : ARRAY) (pr : t ~> ()) a =
   let loop = rec loop => fun i =>
     if i == A.dim then print "\n"
     else (pr (A.sub a i) ; print " " ; loop (i + 1))
@@ -58,8 +58,8 @@ do printArray A32 Int.print a
 type STREAM = {
   type state
   start : state
-  next : state -> state
-  value : state -> int
+  next : state ~> state
+  value : state ~> int
 }
 
 divides k n =
@@ -88,7 +88,7 @@ Sieve :> STREAM = {
   value (s : state) = let S = unwrap s : state in S.value S.start
 }
 
-nthstate = rec (nthstate : int -> Sieve.state) => fun n =>
+nthstate = rec (nthstate : int ~> Sieve.state) => fun n =>
   if n == 0 then Sieve.start else Sieve.next (nthstate (n -1))
 nthprime n = Sieve.value (nthstate n)
 

--- a/talk.1ml
+++ b/talk.1ml
@@ -13,10 +13,10 @@ M = { type point a = {x : a, y : a} }
 M = { point = fun (a : type) => type {x : a, y : a} }
 
 type S = { type point a }
-type S = { point : (a : type) => type }
+type S = { point : (a : type) -> type }
 
 type T = { type point a = {x : a, y : a} }
-type T = { point : (a : type) => (= type {x : a, y : a}) }
+type T = { point : (a : type) -> (= type {x : a, y : a}) }
 
 M' = M : S
 M'' = M :> T
@@ -26,20 +26,20 @@ M'' = M :> T
 
 type EQ = {
   type t
-  eq : t -> t -> bool
+  eq : t -> t ~> bool
 }
 
 type MAP = {
   type key
   type map a
   empty a : map a
-  lookup a : key -> map a -> opt a
-  add a : key -> a -> map a -> map a
+  lookup a : key -> map a ~> opt a
+  add a : key -> a -> map a ~> map a
 }
 
 Map (Key : EQ) :> MAP with (type key = Key.t) = {
   type key = Key.t
-  type map a = key -> opt a
+  type map a = key ~> opt a
   empty (a : type) = fun (x : key) => none
   lookup (a : type) (x : key) (m : map a) = m x
   add (a : type) (x : key) (y : a) (m : map a) =
@@ -53,13 +53,13 @@ type MAP = {
   type key
   type map a
   empty 'a : map a
-  lookup 'a : key -> map a -> opt a
-  add 'a : key -> a -> map a -> map a
+  lookup 'a : key -> map a ~> opt a
+  add 'a : key -> a -> map a ~> map a
 }
 
 Map (Key : EQ) :> MAP with (type key = Key.t) = {
   type key = Key.t
-  type map a = key -> opt a
+  type map a = key ~> opt a
   empty = fun x => none
   lookup x m = m x
   add x y m = fun z => if Key.eq z x then some y else m z
@@ -68,7 +68,7 @@ Map (Key : EQ) :> MAP with (type key = Key.t) = {
 
 ;; Higher-rank polymorphism
 
-f (id : 'a => a -> a) = (id 5, id "text")
+f (id : 'a -> a -> a) = (id 5, id "text")
 
 
 ;; Asociated types
@@ -77,9 +77,9 @@ type COLL c = {
   type key
   type val
   empty : c
-  add : c -> key -> val -> c
-  lookup : c -> key -> opt val
-  keys : c -> list key
+  add : c -> key -> val ~> c
+  lookup : c -> key ~> opt val
+  keys : c ~> list key
 }
 
 entries 'c (C : COLL c) xs : list (type (C.key, C.val)) =
@@ -88,29 +88,28 @@ entries 'c (C : COLL c) xs : list (type (C.key, C.val)) =
 
 ;; Higher-kinded polymorphism
 
-type MONAD (m : type => type) = {
-  return 'a : a -> m a
-  bind 'a 'b : m a -> (a -> m b) -> m b
+type MONAD (m : type -> type) = {
+  return 'a : a ~> m a
+  bind 'a 'b : m a -> (a ~> m b) ~> m b
 }
 
-map 'a 'b (m : type => type) (M : MONAD m) (f : a -> b) mx =
+map 'a 'b (m : type -> type) (M : MONAD m) (f : a ~> b) mx =
   M.bind mx (fun x => M.return (f x))
 
-do map :
-  'a => 'b => (m : type => type) => (M : MONAD m) => (a -> b) -> m a -> m b
+do map : 'a -> 'b -> (m: type -> type) -> (M: MONAD m) -> (a ~> b) ~> m a ~> m b
 
 
 ;; Objects
 
 type point' self = {
-  getX : () -> int
-  getY : () -> int
-  move : int -> int -> self
+  getX : () ~> int
+  getY : () ~> int
+  move : int ~> int ~> self
 }
 type recpoint = rec (x : type) => point' x
 type point = point' recpoint
 
-newpoint = rec (newpoint : int => int => point) => fun x y => {
+newpoint = rec (newpoint : int -> int -> point) => fun x y => {
   getX () = x
   getY () = y
   move dx dy = @recpoint (newpoint (x + dx) (y + dy))

--- a/test.1ml
+++ b/test.1ml
@@ -79,12 +79,12 @@ type OPT = {
   type opt a
   none 'a : opt a
   some 'a : a -> opt a
-  caseopt 'a 'b : opt a -> b -> (a -> b) -> b
+  caseopt 'a 'b : opt a -> b -> (a ~> b) ~> b
 }
 Opt :> OPT = {
-  type opt a = wrap (b : type) => b -> (a -> b) -> b
-  none = wrap (fun (b : type) (n : b) (s : _ -> b) => n) : opt _
-  some x = wrap (fun (b : type) (n : b) (s : _ -> b) => s x) : opt _
+  type opt a = wrap (b : type) -> b -> (a ~> b) ~> b
+  none = wrap (fun (b : type) (n : b) (s : _ ~> b) => n) : opt _
+  some x = wrap (fun (b : type) (n : b) (s : _ ~> b) => s x) : opt _
   caseopt xo = (unwrap xo : opt _) _
 }
 ...Opt
@@ -95,12 +95,12 @@ type ALT = {
   type alt a b
   left 'a 'b : a -> alt a b
   right 'a 'b : b -> alt a b
-  casealt 'a 'b 'c : alt a b -> (a -> c) -> (b -> c) -> c
+  casealt 'a 'b 'c : alt a b -> (a ~> c) -> (b ~> c) ~> c
 }
 Alt :> ALT = {
-  type alt a b = wrap (c : type) => (a -> c) -> (b -> c) -> c
-  left x = wrap (fun (c : type) (l : _ -> c) (r : _ -> c) => l x) : alt _ _
-  right x = wrap (fun (c : type) (l : _ -> c) (r : _ -> c) => r x) : alt _ _
+  type alt a b = wrap (c : type) -> (a ~> c) -> (b ~> c) ~> c
+  left x = wrap (fun (c : type) (l : _ ~> c) (r : _ ~> c) => l x) : alt _ _
+  right x = wrap (fun (c : type) (l : _ ~> c) (r : _ ~> c) => r x) : alt _ _
   casealt xy = (unwrap xy : alt _ _) _
 }
 ...Alt
@@ -111,28 +111,28 @@ type LIST_CORE = {
   type list a
   nil 'a : list a
   cons 'a : a -> list a -> list a
-  foldr 'a 'b : list a -> b -> (a -> b -> b) -> b
+  foldr 'a 'b : list a -> b -> (a ~> b ~> b) ~> b
 }
 type LIST = {
   ...LIST_CORE
-  caselist 'a 'b : list a -> b -> (a -> list a -> b) -> b
-  isNil 'a : list a -> bool
-  head 'a : list a -> opt a
-  tail 'a : list a -> opt (list a)
-  length 'a : list a -> int
-  cat 'a : list a -> list a -> list a
-  rev 'a : list a -> list a
-  nth 'a : list a -> int -> opt a
-  map 'a 'b : list a -> (a -> b) -> list b
-  foldl 'a 'b : list a -> b -> (b -> a -> b) -> b
-;;  foldr 'a 'b : list a -> b -> (a -> b -> b) -> b
+  caselist 'a 'b : list a -> b -> (a ~> list a ~> b) ~> b
+  isNil 'a : list a ~> bool
+  head 'a : list a ~> opt a
+  tail 'a : list a ~> opt (list a)
+  length 'a : list a ~> int
+  cat 'a : list a -> list a ~> list a
+  rev 'a : list a ~> list a
+  nth 'a : list a -> int ~> opt a
+  map 'a 'b : list a -> (a ~> b) ~> list b
+  foldl 'a 'b : list a -> b -> (b ~> a ~> b) ~> b
+;;  foldr 'a 'b : list a -> b -> (a ~> b ~> b) ~> b
 }
 List :> LIST = {
   ...{
-    type list a = wrap (b : type) => b -> (a -> b -> b) -> b
-    nil = wrap (fun (b : type) (n : b) (c : _ -> b -> b) => n) : list _
+    type list a = wrap (b : type) -> b -> (a ~> b ~> b) ~> b
+    nil = wrap (fun (b : type) (n : b) (c : _ ~> b ~> b) => n) : list _
     cons x xs =
-      wrap (fun (b : type) (n : b) (c : _ -> b -> b) =>
+      wrap (fun (b : type) (n : b) (c : _ ~> b ~> b) =>
         c x ((unwrap xs : list _) b n c)) : list _
     foldr xs = (unwrap xs : list _) _
   } :> LIST_CORE
@@ -155,10 +155,10 @@ List :> LIST = {
 }
 (;
 List :> LIST = {
-  type list a = (b : type) => b -> (a -> b -> b) -> b
-  nil a b (n : b) (c : a -> b -> b) = n
-  cons a (x : a) (xs : list a) b (n : b) (c : a -> b -> b) = c x (xs b n c)
-  foldr a b (xs : list a) = xs b : b -> (a -> b -> b) -> b
+  type list a = (b : type) -> b -> (a ~> b ~> b) ~> b
+  nil a b (n : b) (c : a ~> b ~> b) = n
+  cons a (x : a) (xs : list a) b (n : b) (c : a ~> b ~> b) = c x (xs b n c)
+  foldr a b (xs : list a) = xs b : b -> (a ~> b ~> b) ~> b
   isNil a (xs : list a) =
     foldr a bool xs true (fun (_ : a) (_ : bool) => false)
   head a (xs : list a) =
@@ -169,7 +169,7 @@ List :> LIST = {
       (nil a, none (list a))
       (fun (x : a) (acc : t) => (cons a x acc.1, some (list a) acc.1))
     ).2
-  caselist a b (xs : list a) (n : b) (c : a -> list a -> b) =
+  caselist a b (xs : list a) (n : b) (c : a ~> list a ~> b) =
     caseopt a b (head a xs)
       n
       (fun (x : a) => caseopt (list a) b (tail a xs)
@@ -182,9 +182,9 @@ List :> LIST = {
   rev a (xs : list a) =
     foldr a (list a) xs (nil a)
       (fun (x : a) (xs : list a) => cat a xs (cons a x (nil a)))
-  map a b (xs : list a) (f : a -> b) =
+  map a b (xs : list a) (f : a ~> b) =
     foldr a (list b) xs (nil b) (fun (x : a) => cons b (f x))
-  foldl a b (xs : list a) (x : b) (f : b -> a -> b) =
+  foldl a b (xs : list a) (x : b) (f : b ~> a ~> b) =
     foldr a b (rev a xs) x (fun (x : a) (y : b) => f y x)
   nth a (xs : list a) (n : int) =
     let (==) = equal int in
@@ -201,7 +201,7 @@ do log "Set"
 
 type ORD = {
   type t
-  (<=) : t => t -> bool
+  (<=) : t -> t ~> bool
 }
 
 type SET = {
@@ -209,14 +209,14 @@ type SET = {
   type elem
   type t = set
   empty : set
-  add : elem -> set -> set
-  mem : elem -> set -> bool
-  card : set -> int
+  add : elem -> set ~> set
+  mem : elem -> set ~> bool
+  card : set ~> int
 }
 
 Set (Elem : ORD) :> SET with (elem = Elem.t) = {
   type elem = Elem.t
-  type set = (int, elem -> bool)
+  type set = (int, elem ~> bool)
   type t = set
   empty = (0, fun (x : elem) => false)
   card (s : set) = s._1
@@ -233,13 +233,13 @@ type MAP = {
   type key
   type t a = map a
   empty 'a : map a
-  add 'a : key -> a -> map a -> map a
-  lookup 'a : key -> map a -> opt a
+  add 'a : key -> a -> map a ~> map a
+  lookup 'a : key -> map a ~> opt a
 }
 
 Map (Key : ORD) :> MAP with (key = Key.t) = {
   type key = Key.t
-  type map a = key -> opt a
+  type map a = key ~> opt a
   t = map
   empty x = none
   lookup x m = m x
@@ -257,7 +257,7 @@ TestSetAndMap = {
 
 let
   f x = nil
-  g 'a : () -> list a = f
+  g 'a : () ~> list a = f
 in {
   G (type t) = {
     ...{type u = t, v = nil} :> {type u, v : list u}

--- a/types.ml
+++ b/types.ml
@@ -783,9 +783,9 @@ let rec print_typ' prec ctxt = function
       print_string " ";
       print_string
         (match f with
-        | Explicit Impure -> "->"
-        | Explicit Pure -> "=>"
-        | Implicit -> "'=>"
+        | Explicit Impure -> "~>"
+        | Explicit Pure -> "->"
+        | Implicit -> "'->"
         );
       print_break 1 2;
       open_box 0;


### PR DESCRIPTION
This change is made in preparation for implementing polymorphic effects.