### PR TITLE
Fix bug in substitution of semantics types

### DIFF
--- a/regression.1ml
+++ b/regression.1ml
@@ -36,6 +36,26 @@ Equivalence: {
 
 ;;
 
+AmateurOptics = {
+  type FUNCTOR = {
+    type t a
+    map 'a 'b: (a ~> b) -> t a ~> t b
+  }
+
+  type lens a b s t = (F: FUNCTOR) -> (a ~> F.t b) -> s ~> F.t t
+
+  ;; NOTE: It is important that the following do not have more type annotations,
+  ;; because the bug that this triggered was due to treatment of inferred types.
+
+  ((l1: lens _ _ _ _) <-< (l2: lens _ _ _ _)) (F: FUNCTOR) toF = l1 F (l2 F toF)
+
+  e1 (F: FUNCTOR) abF (l, r) = F.map (fun l => (l, r)) (abF l)
+
+  e11 = e1 <-< e1
+}
+
+;;
+
 brace_style_1 = {x = 1, y = 2}
 brace_style_2 = {
   x = 1

--- a/types.ml
+++ b/types.ml
@@ -182,7 +182,10 @@ let rec contains_typ a = function
   | TupT(r) -> contains_row a r
   | DotT(t, l) -> contains_typ a t
   | RecT(ak, t) -> not (contains_bind a [ak]) && contains_typ a t
-  | InferT(z) -> false
+  | InferT(z) ->
+    match !z with
+    | Det t -> contains_typ a t
+    | Undet _ -> true
 
 and contains_extyp a = function
   | ExT(aks, t) -> not (contains_bind a aks) && contains_typ a t


### PR DESCRIPTION
When determining whether a type contains a variable, any undetermined inferred type may end up containing the variable.