### PR TITLE
Change syntax of path exps to have typs and dot path exps as args

### DIFF
--- a/paper.1ml
+++ b/paper.1ml
@@ -97,7 +97,7 @@ type COLL c = {
   lookup : c -> key ~> opt val
   keys : c ~> list key
 }
-entries (c : type) (C : COLL c) (xs : c) : list (type (C.key, C.val)) =
+entries (c : type) (C : COLL c) (xs : c) : list (C.key, C.val) =
   List.map (C.keys xs) (fun (k : C.key) => (k, caseopt (C.lookup xs k) bot id))
 
 type MONAD (m : type -> type) = {

--- a/parser.mly
+++ b/parser.mly
@@ -278,8 +278,10 @@ atpathexp :
 apppathexp :
   | dotpathexp
     { $1 }
-  | apppathexp dotexp
+  | apppathexp dotpathexp
     { appE($1, $2)@@at() }
+  | apppathexp attyp
+    { appE($1, TypE($2)@@ati 2)@@at() }
   | AT attyp atexp
     { rollE($3, $2)@@at() }
   | AT name atexp

--- a/prelude/index.1ml
+++ b/prelude/index.1ml
@@ -48,7 +48,7 @@ Alt = {
 ;;
 
 Opt = {
-  type t x = Alt.t (type {}) x
+  type t x = Alt.t {} x
   none = Alt.inl ()
   some = Alt.inr
   case {none, some} = Alt.case {inl () = none, inr = some}

--- a/regression.1ml
+++ b/regression.1ml
@@ -208,13 +208,13 @@ Hungry = {
 
 PolyRec = {
   type l a = rec (type t) => a | t
-  ...rec {type t a} => {type t a = a | t (type (a, a))}
+  ...rec {type t a} => {type t a = a | t (a, a)}
 
   t_int = t int
 
   hmm (x: t int) = flip Alt.case (x.@(t int))
 
-  t0 = @(t int) (inr (@(t (type (int, int))) (inl (0, 0))))
+  t0 = @(t int) (inr (@(t (int, int)) (inl (0, 0))))
 }
 
 N :> {

--- a/talk.1ml
+++ b/talk.1ml
@@ -82,7 +82,7 @@ type COLL c = {
   keys : c ~> list key
 }
 
-entries 'c (C : COLL c) xs : list (type (C.key, C.val)) =
+entries 'c (C : COLL c) xs : list (C.key, C.val) =
   List.map (C.keys xs) (fun k => caseopt (C.lookup xs k) bot (fun v => (k, v)))
 
 


### PR DESCRIPTION
For example, one previously wrote

    ap 'a 'b: f (type a -> b) -> f a -> f b

and now one writes

    ap 'a 'b: f (a -> b) -> f a -> f b

which is both more concise and also more familiar.

[Card](https://github.com/orgs/1ml-prime/projects/1#card-35979775)