### PR TITLE
Change to layout sensitively insert parens around `_ => _` exprs

### DIFF
--- a/regression.1ml
+++ b/regression.1ml
@@ -89,6 +89,25 @@ Control = {
        fun {} => 42
 }
 
+Monadic = {
+  type MONAD = {
+    type t _
+    of 'x: x ~> t x
+    chain 'x 'y: (x ~> t y) -> t x ~> t y
+  }
+
+  Ops (M: MONAD) = {
+    ...M
+    xM >>= xyM = chain xyM xM
+    xM >> yM = xM |> chain fun {} => yM
+  }
+
+  monadic (M: MONAD) = let ...Ops M
+    of 101 >>= fun x =>
+    of {} >>
+    of x
+}
+
 ;;
 
 hole_is_allowed_type_pattern (type _ _) = ()

--- a/regression.1ml
+++ b/regression.1ml
@@ -26,12 +26,12 @@ Equivalence: {
   wr (eq: T _ _) = wrap eq: t _ _
   un eq = unwrap eq: t _ _
   transitivity 'a 'b 'c (ab: t a b) (bc: t b c) =
-    wr (fun (type p _) => un bc p << un ab p)
-  reflexivity = wr (fun (type p _) => id)
+    wr fun (type p _) => un bc p << un ab p
+  reflexivity = wr fun (type p _) => id
   to eq a = un eq (fun (type x) => x) a
   from 'a 'b (eq: t a b) b = un eq (fun (type b) => type b ~> a) id b
   symmetry 'a 'b (eq: t a b) : t b a =
-    wr (fun (type p _) => un eq (fun (type b) => type p b ~> p a) id)
+    wr fun (type p _) => un eq (fun (type b) => type p b ~> p a) id
 }
 
 ;;
@@ -80,6 +80,14 @@ seq_exps x : (_, _) =
     x + y,
     Int.print 10; 1
   )
+
+Control = {
+  ifElse cond onT onF = if cond then onT () else onF ()
+
+  do ifElse true
+       fun {} => 101
+       fun {} => 42
+}
 
 ;;
 
@@ -199,7 +207,7 @@ type (a `>>` b) c = c
 Hungry = {
   type eat a = rec eat_a => a ~> eat_a
 
-  eater 'a: eat a = rec (eater: eat a) => @(eat a) (fun a => eater)
+  eater 'a: eat a = rec (eater: eat a) => @(eat a) fun a => eater
 
   eater <+ x = eater.@(eat _) x
 
@@ -238,8 +246,8 @@ in {
     (unwrap e.@(t _ _): wrap T x n t) p cs
 
   let mk 'x 'n (c: T x n t) = @(t x n) (wrap c: wrap T x n t) in {
-    nil  'x                     = mk (fun (type p _) (r: I x p t) => r.nil)
-    'x (v: x) :: 'n (vs: t x n) = mk (fun (type p _) (r: I x p t) => r.:: v vs)
+    nil  'x                     = mk fun (type p _) (r: I x p t) => r.nil
+    'x (v: x) :: 'n (vs: t x n) = mk fun (type p _) (r: I x p t) => r.:: v vs
   }
 } :> {
   type t _ _


### PR DESCRIPTION
This allows to omit parentheses around `fun _ => _` and `rec _ => _` expressions
in many.  For example, monadic code can now be written more legibly:

    action >>= fun () ->
    get >>= fun x ->
    set x

Related [card](https://github.com/orgs/1ml-prime/projects/1#card-35978718).

Also relaxed the layout rules for operator symbols such that it is possible to write

    m1 >>
    m2

and

    x
    |> f

and even

       x
    |> f

similar to e.g. F#.