### PR TITLE
Change and generalize syntax of annotations, (un)wraps, (un)rolls

### DIFF
--- a/lexer.mll
+++ b/lexer.mll
@@ -253,12 +253,14 @@ rule token = parse
   | "rec" { REC }
   | "then" { THEN }
   | "type" { TYPE }
-  | "unwrap" { UNWRAP }
   | "with" { WITH }
-  | "@" { AT }
   | "=" { EQUAL }
   | ":" { COLON }
   | ":>" { SEAL }
+  | ":@" { ROLL_OP }
+  | "@:" { UNROLL_OP }
+  | ":#" { WRAP_OP }
+  | "#:" { UNWRAP_OP }
   | "->" { ARROW }
   | "~>" { SARROW }
   | "=>" { DARROW }

--- a/paper.1ml
+++ b/paper.1ml
@@ -87,7 +87,7 @@ f (id : (a : type) -> a ~> a) = {x = id int 5, y = id bool true}
 
 type SHAPE = {type t, area : t ~> int, v : t}
 volume (height : int) (s : SHAPE) = height * s.area s.v
-area ss = List.foldl ss 0 (fun a (wrap s : wrap SHAPE) => a + s.area s.v)
+area ss = List.foldl ss 0 (fun a (s :# wrap SHAPE) => a + s.area s.v)
 
 type COLL c = {
   type key
@@ -266,7 +266,7 @@ type OPT = {
 }
 Opt :> OPT = {
   type opt a = wrap (b : type) -> b -> (a ~> b) ~> b
-  none 'a = wrap (fun (b : type) (n : b) (s : a ~> b) => n) : opt a
-  some 'a x = wrap (fun (b : type) (n : b) (s : a ~> b) => s x) : opt a
-  caseopt 'a 'b xo = (unwrap xo : opt a) b
+  none 'a :# opt a = fun (b : type) (n : b) (s : a ~> b) => n
+  some 'a x :# opt a = fun (b : type) (n : b) (s : a ~> b) => s x
+  caseopt 'a 'b (xo :# opt a) = xo b
 }

--- a/parser.mly
+++ b/parser.mly
@@ -26,17 +26,19 @@ let parse_error s = raise (Source.Error (Source.nowhere_region, s))
 %}
 
 %token HOLE PRIMITIVE
-%token FUN REC LET IN DO WRAP UNWRAP TYPE ELLIPSIS
+%token FUN REC LET IN DO WRAP TYPE ELLIPSIS
 %token IF THEN ELSE LOGICAL_OR LOGICAL_AND AS
 %token EQUAL COLON SEAL ARROW SARROW DARROW
 %token WITH
 %token LPAR RPAR
 %token LBRACE RBRACE
-%token DOT AT TICK
+%token DOT TICK
 %token COMMA SEMI
 %token TYPE_ERROR
 %token LOCAL
 %token IMPORT
+%token WRAP_OP UNWRAP_OP
+%token ROLL_OP UNROLL_OP
 
 %token EOF
 
@@ -262,10 +264,6 @@ dotpathexp :
     { $1 }
   | dotpathexp DOT label
     { DotE($1, $3)@@at() }
-  | dotpathexp DOT AT attyp
-    { unrollE($1, $4)@@at() }
-  | dotpathexp DOT AT name
-    { unrollE($1, PathT(VarE($4)@@ati 4)@@ati 4)@@at() }
 ;
 atpathexp :
   | name
@@ -280,10 +278,6 @@ apppathexp :
     { appE($1, $2)@@at() }
   | apppathexp attyp
     { appE($1, TypE($2)@@ati 2)@@at() }
-  | AT attyp atexp
-    { rollE($3, $2)@@at() }
-  | AT name atexp
-    { rollE($3, PathT(VarE($2)@@ati 2)@@ati 2)@@at() }
 ;
 infpathexp :
   | apppathexp
@@ -303,10 +297,6 @@ dotexp :
     { $1 }
   | dotexp DOT label
     { DotE($1, $3)@@at() }
-  | dotexp DOT AT attyp
-    { unrollE($1, $4)@@at() }
-  | dotexp DOT AT name
-    { unrollE($1, PathT(VarE($4)@@ati 4)@@ati 4)@@at() }
 ;
 atexp :
   | name
@@ -339,10 +329,6 @@ appexp :
     { $1 }
   | appexp dotexp
     { appE($1, $2)@@at() }
-  | AT attyp atexp
-    { rollE($3, $2)@@at() }
-  | AT name atexp
-    { rollE($3, PathT(VarE($2)@@ati 2)@@ati 2)@@at() }
 ;
 infexp :
   | appexp
@@ -356,17 +342,27 @@ infexp :
   | infexp LOGICAL_AND appexp
     { andE($1, $3)@@at() }
 ;
+annexp_op :
+  | COLON
+    { annotE }
+  | SEAL
+    { sealE }
+  | ROLL_OP
+    { rollE }
+  | UNROLL_OP
+    { unrollE }
+  | WRAP_OP
+    { wrapE }
+  | UNWRAP_OP
+    { unwrapE }
+;
 annexp :
-  | infexp optannot
-    { opt annotE($1, $2)@@at() }
+  | infexp
+    { $1 }
   | TYPE typ
     { TypE($2)@@at() }
-  | annexp SEAL typ
-    { sealE($1, $3)@@at() }
-  | WRAP infexp COLON typ
-    { wrapE($2, $4)@@at() }
-  | UNWRAP infexp COLON typ
-    { unwrapE($2, $4)@@at() }
+  | annexp annexp_op typ
+    { $2($1, $3)@@at() }
 ;
 inexp :
   | annexp
@@ -403,18 +399,42 @@ funbind :
     { ($3, $2 @ $4 @ $6) }
 ;
 
+bindann_op :
+  | COLON
+    { annotE }
+  | SEAL
+    { sealE }
+  | ROLL_OP
+    { rollE }
+  | UNROLL_OP
+    { unrollE }
+  | WRAP_OP
+    { wrapE }
+  | UNWRAP_OP
+    { unwrapE }
+;
+bindann :
+  | bindann_op typ
+    { fun e -> $1(e, $2)@@span[ati 2; e.at] }
+;
+bindanns :
+  | bindann
+    { $1 }
+  | bindanns bindann
+    { fun e -> $2 ($1 e) }
+;
+bindanns_opt :
+  |
+    { fun e -> e }
+  | bindanns
+    { $1 }
+;
+
 atbind :
-  | funbind optannot EQUAL exp
-    { let (head, params) = $1 in
-      VarB(head, funE(params,
-        opt annotE($4, $2)@@span[ati 2; ati 4])@@at())@@at() }
-  | funbind SEAL typ EQUAL exp
-    { let (head, params) = $1 in
-      VarB(head, funE(params, sealE($5, $3)@@span[ati 3; ati 5])@@at())@@at() }
-  | head SEAL typ EQUAL exp
-    { VarB($1, sealE($5, $3)@@span[ati 3; ati 5])@@at() }
-  | pat EQUAL exp
-    { patB($1, $3)@@at() }
+  | funbind bindanns_opt EQUAL exp
+    { let (head, params) = $1 in VarB(head, funE(params, $2($4))@@at())@@at() }
+  | atpat bindanns_opt EQUAL exp
+    { patB($1, $2($4))@@at() }
   | name
     { VarB($1, VarE($1.it@@at())@@at())@@at() }
   | typpat EQUAL typ
@@ -461,19 +481,19 @@ atpat :
       annotP(headP(head)@@head.at,
         funT(typparams, TypT@@at(), Pure@@at())@@at())@@at() }
 ;
-apppat :
-  | atpat
-    { $1 }
-  | AT attyp atpat
-    { rollP($3, $2)@@at() }
-  | AT name atpat
-    { rollP($3, PathT(VarE($2)@@ati 2)@@ati 2)@@at() }
+annpat_op :
+  | COLON
+    { annotP }
+  | ROLL_OP
+    { rollP }
+  | WRAP_OP
+    { wrapP }
 ;
 annpat :
-  | apppat optannot
-    { opt annotP($1, $2)@@at() }
-  | WRAP apppat COLON typ
-    { wrapP($2, $4)@@at() }
+  | atpat
+    { $1 }
+  | annpat annpat_op typ
+    { $2($1, $3)@@at() }
 ;
 pat :
   | annpat

--- a/prelude.1ml
+++ b/prelude.1ml
@@ -112,9 +112,9 @@ type OPT = {
 }
 Opt :> OPT = {
   type opt a = wrap (b : type) -> (() ~> b) -> (a ~> b) ~> b
-  none 'a = wrap (fun (b : type) (n : () ~> b) (s : a ~> b) => n ()) : opt a
-  some 'a x = wrap (fun (b : type) (n : () ~> b) (s : a ~> b) => s x) : opt a
-  caseopt xo = (unwrap xo : opt _) _
+  none 'a :# opt a = fun (b : type) (n : () ~> b) (s : a ~> b) => n ()
+  some 'a x :# opt a = fun (b : type) (n : () ~> b) (s : a ~> b) => s x
+  caseopt (xo :# opt _) = xo _
 }
 ...Opt
 
@@ -129,11 +129,11 @@ type ALT = {
 }
 Alt :> ALT = {
   type alt a b = wrap (c : type) -> (a ~> c) -> (b ~> c) ~> c
-  left 'a 'b x =
-    wrap (fun (c : type) (l : a ~> c) (r : b ~> c) => l x) : alt a b
-  right 'a 'b x =
-    wrap (fun (c : type) (l : a ~> c) (r : b ~> c) => r x) : alt a b
-  casealt xy = (unwrap xy : alt _ _) _
+  left 'a 'b x :# alt a b =
+    fun (c : type) (l : a ~> c) (r : b ~> c) => l x
+  right 'a 'b x :# alt a b =
+    fun (c : type) (l : a ~> c) (r : b ~> c) => r x
+  casealt (xy :# alt _ _) = xy _
 }
 ...Alt
 
@@ -163,11 +163,11 @@ type LIST = {
 List :> LIST = {
   ...{
     type list a = wrap (b : type) -> b -> (a ~> b ~> b) ~> b
-    nil 'a = wrap (fun (b : type) (n : b) (c : a ~> b ~> b) => n) : list _
-    cons x xs =
-      wrap (fun (b : type) (n : b) (c : _ ~> b ~> b) =>
-        c x ((unwrap xs : list _) b n c)) : list _
-    foldr xs = (unwrap xs : list _) _
+    nil 'a :# list _ = fun (b : type) (n : b) (c : a ~> b ~> b) => n
+    cons x (xs :# list _) :# list _ =
+      fun (b : type) (n : b) (c : _ ~> b ~> b) =>
+        c x (xs b n c)
+    foldr (xs :# list _) = xs _
   } :> LIST_CORE
   isNil xs = foldr xs true (fun _ _ => false)
   head xs = foldr xs none (fun x _ => some x)

--- a/prelude/index.1ml
+++ b/prelude/index.1ml
@@ -33,9 +33,9 @@ Alt :> {
   case 'a 'b 'o: {inl: a ~> o, inr: b ~> o} -> t a b ~> o
 } = {
   type t a b = wrap 'o -> {inl: a ~> o, inr: b ~> o} ~> o
-  inl x = wrap (fun c => c.inl x): t _ _
-  inr x = wrap (fun c => c.inr x): t _ _
-  case c (wrap x: t _ _) = x c
+  inl x :# t _ _ = fun c => c.inl x
+  inr x :# t _ _ = fun c => c.inr x
+  case c (x :# t _ _) = x c
 }
 
 Alt = {
@@ -69,9 +69,9 @@ Pair = {
 List = {
   local ...Opt, ...Fun
   ...rec {type t _} => {type t x = Opt.t (x, t x)}
-  nil = @(t _) none
-  hd :: tl = @(t _) (some (hd, tl))
-  case {nil, (::)} (@(t _) x) = x |> Opt.case {
+  nil :@ t _ = none
+  hd :: tl :@ t _ = some (hd, tl)
+  case {nil, (::)} (x :@ t _) = x |> Opt.case {
     none = nil
     some (hd, tl) = hd :: tl
   }

--- a/readme.1ml
+++ b/readme.1ml
@@ -1,0 +1,86 @@
+local import "prelude.1ml"
+
+
+
+do Int.print (3 + 5)
+
+
+
+type t = int              ;; t = type int
+type pair x y = (x, y)    ;; pair = fun (x : type) => fun (y : type) => (x, y)
+
+type MONAD (m : type -> type) = {
+  return 'a : a ~> m a
+  bind 'a 'b : m a -> (a ~> m b) ~> m b
+}
+
+type SIG = {
+  type t                       ;; t : type
+  type u a                     ;; u : (a : type) -> type
+  type v = int                 ;; v : (= type int)
+  type w a (c : type -> type) = (u a, c t)
+  ;; w : (a : type) -> (c : (_ : type) -> type) -> (= type {_1: u a, _2: c t})
+}
+
+
+
+pair x y = {fst = x, snd = y}
+p = pair 5 "foo"
+
+
+
+do {pair} : {pair 'a 'b : a -> b -> {fst : a, snd : b}}
+
+
+
+do {pair} : {pair : 'a -> 'b -> a -> b -> {fst : a, snd : b}}
+
+
+
+do {pair} : {pair : '(a : type) -> '(b : type) -> a -> b -> {fst : a, snd : b}}
+
+
+
+f (id 'a : a -> a) = (id 5, id "")
+p = f (fun x => x)
+
+
+
+type stream = rec t => {hd : int, tl : () ~> opt t} ;; creates rec type
+single x :@ stream = {hd = x, tl = fun () => none}  ;; b :@ t rolls value into t
+({hd = n} :@ stream) = single 5        ;; p :@ t pattern matches on rec value
+do Int.print n                         ;; or:
+do Int.print (single 7 @: stream).hd   ;; e @: t unrolls rec value directly
+
+
+
+
+count = rec self => fun i =>
+  if i == 0 then () else self (i - 1)
+
+repeat = rec self => fun x =>
+  {hd = x, tl = fun () => some (self x)} :@ stream
+
+
+
+{even, odd} = rec (self : {even : int ~> stream, odd : int ~> stream}) => {
+  even x :@ stream = {hd = x, tl = fun () => some (self.odd (x + 1))}
+  odd x :@ stream = {hd = x, tl = fun () => some (self.even (x + 1))}
+}
+
+
+
+type OPT = {
+  type opt a
+  none 'a : opt a
+  some 'a : a -> opt a
+  caseopt 'a 'b : opt a -> b -> (a ~> b) ~> b
+}
+Opt :> OPT = {
+  ;; Church encoding; it requires the abstract type opt a to be implemented
+  ;; with a polymorphic (i.e., large) type. Thus, wrap the type.
+  type opt a = wrap (b : type) -> b -> (a ~> b) ~> b
+  none :# opt _ = fun (b : type) (n : b) (s : _ ~> b) => n
+  some x :# opt _ = fun (b : type) (n : b) (s : _ ~> b) => s x
+  caseopt (xo :# opt _) = xo _
+}

--- a/regression.1ml
+++ b/regression.1ml
@@ -23,8 +23,8 @@ Equivalence: {
 } = {
   type T a b = (type p _) ~> p a ~> p b
   type t a b = wrap T a b
-  wr (eq: T _ _) = wrap eq: t _ _
-  un (wrap eq: t _ _) = eq
+  wr (eq: T _ _) :# t _ _ = eq
+  un (eq :# t _ _) = eq
   transitivity 'a 'b 'c (ab: t a b) (bc: t b c) =
     wr fun (type p _) => un bc p << un ab p
   reflexivity = wr fun (type p _) => id
@@ -133,7 +133,7 @@ type_error {
 
 
 Both = {
-  {x, y = _} as {x = _, y} = {x = 1, y = 2}
+  ({x, y = _} as {x = _, y}) = {x = 1, y = 2}
 }
 
 ;;
@@ -167,9 +167,7 @@ type_error rec (R: {}) => {
   kaboom () = R
 }
 
-Kaboom = rec (R: rec R => {kaboom: () ~> R}) => @(= R) {
-  kaboom () = R
-}
+Kaboom = rec (R: rec R => {kaboom: () ~> R}) => {kaboom () = R} :@ (= R)
 
 ;;
 
@@ -196,15 +194,15 @@ in {
   }) => {
     Even = {
       ...T.Even
-      make 'x (head: x) (tail: T.Odd.t x) : T.Even.t x =
-        @(T.Even.t x) {head, tail}
-      size 'x (v: T.Even.t x) = 1 + R.Odd.size v.@(T.Even.t _).tail
+      make 'x (head: x) (tail: T.Odd.t x) :@ T.Even.t x =
+        {head, tail}
+      size 'x (v :@ T.Even.t x) = 1 + R.Odd.size v.tail
     }
     Odd = {
       ...T.Odd
-      make 'x (v: opt (T.Even.t x)) : T.Odd.t x = @(T.Odd.t x) v
-      size 'x (v: T.Odd.t x) =
-        v.@(T.Odd.t x) |> Opt.case {
+      make 'x (v: opt (T.Even.t x)) :@ T.Odd.t x = v
+      size 'x (v :@ T.Odd.t x) =
+        v |> Opt.case {
           none = 0
           some e = R.Even.size e
         }
@@ -237,9 +235,9 @@ type (a `>>` b) c = c
 Hungry = {
   type eat a = rec eat_a => a ~> eat_a
 
-  eater 'a: eat a = rec (eater: eat a) => @(eat a) fun a => eater
+  eater 'a = rec (eater: eat a) => (fun a => eater) :@ eat a
 
-  eater <+ x = eater.@(eat _) x
+  (eater :@ eat _) <+ x = eater x
 
   do eater <+ 1 <+ 2
 }
@@ -250,9 +248,9 @@ PolyRec = {
 
   t_int = t int
 
-  hmm (x: t int) = flip Alt.case (x.@(t int))
+  hmm (x :@ t int) = flip Alt.case x
 
-  t0 = @(t int) (inr (@(t (int, int)) (inl (0, 0))))
+  t0 = inr (inl (0, 0) :@ t (int, int)) :@ t int
 }
 
 N :> {
@@ -272,10 +270,10 @@ ListN = let
 in {
   ...rec {type t _ _} => {type t x n = wrap T x n t}
 
-  case 'x 'n (type p _) (cs: I x p t) (@(t x n) (wrap e: wrap T x n t)) =
+  case 'x 'n (type p _) (cs: I x p t) (e :# wrap T x n t :@ t x n) =
     e p cs
 
-  let mk 'x 'n (c: T x n t) = @(t x n) (wrap c: wrap T x n t) in {
+  let mk 'x 'n (c: T x n t) = c :# wrap T x n t :@ t x n in {
     nil  'x                     = mk fun (type p _) (r: I x p t) => r.nil
     'x (v: x) :: 'n (vs: t x n) = mk fun (type p _) (r: I x p t) => r.:: v vs
   }

--- a/russo.1ml
+++ b/russo.1ml
@@ -78,14 +78,14 @@ sift (S : STREAM) :> STREAM = {
 
 Sieve :> STREAM = {
   type state = wrap STREAM
-  start = wrap {
+  start :# state = {
     type state = int
     start = 2
     next n = n + 1
     value s = s
-  } : state
-  next (s : state) = let S = unwrap s : state in wrap sift S : state
-  value (s : state) = let S = unwrap s : state in S.value S.start
+  }
+  next (S :# state) :# state = sift S
+  value (S :# state) = S.value S.start
 }
 
 nthstate = rec (nthstate : int ~> Sieve.state) => fun n =>

--- a/talk.1ml
+++ b/talk.1ml
@@ -112,11 +112,11 @@ type point = point' recpoint
 newpoint = rec (newpoint : int -> int -> point) => fun x y => {
   getX () = x
   getY () = y
-  move dx dy = @recpoint (newpoint (x + dx) (y + dy))
+  move dx dy :@ recpoint = newpoint (x + dx) (y + dy)
 }
 
 p = newpoint 3 4
-p' = (p.move 1 2).@recpoint
+p' @: recpoint = p.move 1 2
 do Int.print (p'.getX ())
 do print " "
 do Int.print (p'.getY ())

--- a/test.1ml
+++ b/test.1ml
@@ -83,9 +83,9 @@ type OPT = {
 }
 Opt :> OPT = {
   type opt a = wrap (b : type) -> b -> (a ~> b) ~> b
-  none = wrap (fun (b : type) (n : b) (s : _ ~> b) => n) : opt _
-  some x = wrap (fun (b : type) (n : b) (s : _ ~> b) => s x) : opt _
-  caseopt xo = (unwrap xo : opt _) _
+  none :# opt _ = fun (b : type) (n : b) (s : _ ~> b) => n
+  some x :# opt _ = fun (b : type) (n : b) (s : _ ~> b) => s x
+  caseopt (xo :# opt _) = xo _
 }
 ...Opt
 
@@ -99,9 +99,9 @@ type ALT = {
 }
 Alt :> ALT = {
   type alt a b = wrap (c : type) -> (a ~> c) -> (b ~> c) ~> c
-  left x = wrap (fun (c : type) (l : _ ~> c) (r : _ ~> c) => l x) : alt _ _
-  right x = wrap (fun (c : type) (l : _ ~> c) (r : _ ~> c) => r x) : alt _ _
-  casealt xy = (unwrap xy : alt _ _) _
+  left x :# alt _ _ = fun (c : type) (l : _ ~> c) (r : _ ~> c) => l x
+  right x :# alt _ _ = fun (c : type) (l : _ ~> c) (r : _ ~> c) => r x
+  casealt (xy :# alt _ _) = xy _
 }
 ...Alt
 
@@ -130,11 +130,11 @@ type LIST = {
 List :> LIST = {
   ...{
     type list a = wrap (b : type) -> b -> (a ~> b ~> b) ~> b
-    nil = wrap (fun (b : type) (n : b) (c : _ ~> b ~> b) => n) : list _
-    cons x xs =
-      wrap (fun (b : type) (n : b) (c : _ ~> b ~> b) =>
-        c x ((unwrap xs : list _) b n c)) : list _
-    foldr xs = (unwrap xs : list _) _
+    nil :# list _ = fun (b : type) (n : b) (c : _ ~> b ~> b) => n
+    cons x (xs :# list _) :# list _ =
+      fun (b : type) (n : b) (c : _ ~> b ~> b) =>
+        c x (xs b n c)
+    foldr (xs :# list _) = xs _
   } :> LIST_CORE
   isNil xs = foldr xs true (fun _ _ => false)
   head xs = foldr xs none (fun x _ => some x)
@@ -276,12 +276,11 @@ in {
 
 type int = primitive "int"
 type t = rec a => int
-v = @t 3
-n = v.@t
-@t m = v
+v = 3 :@ t
+n = v @: t
+(m :@ t) = v
 type u a = rec _ => a
-w = @(u int) 4
-@(u int) x = w
-type p a b = (a,b)
-@(u (p _ _))(@t x, y) = @(u (p _ _)) (@t 6, 7)
-@(u _)(@t x', y') = @(u _) (@t 6, 7)
+w = 4 :@ u int
+(x :@ u int) = w
+((x :@ t, y) :@ u (_, _)) = (6 :@ t, 7) :@ u (_, _)
+((x' :@ t, y') :@ u _) = (6 :@ t, 7) :@ u _


### PR DESCRIPTION
    exp  :  t     ;; annot
    exp  :> t     ;; seal
    exp  :@ t     ;; wrap
    exp  :# t     ;; roll
    exp @:  t     ;; unroll
    exp #:  t     ;; unwrap

    bind  :  t = exp   :=   bind = exp  :  t
    bind  :> t = exp   :=   bind = exp  :> t
    bind  :@ t = exp   :=   bind = exp  :@ t
    bind  :# t = exp   :=   bind = exp  :# t
    bind @:  t = exp   :=   bind = exp @:  t
    bind #:  t = exp   :=   bind = exp #:  t

    pat :  t      ;; annot pat
    pat :@ t      ;; roll pat -> binding unrolled
    pat :# t      ;; wrap pat -> binding unwrapped

This essentially rejects the [card](https://github.com/orgs/1ml-prime/projects/1#card-35764576) by actually generalizing the notations in a more compositional manner.

This is related to [card](https://github.com/orgs/1ml-prime/projects/1#card-35764542) in the sense that the generalized syntax may reduce the need for duplicated type annotations.