### PR TITLE
Change type notation to allow non base kind paths and fun exprs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ matrix:
             - ocaml
     - os: osx
       osx_image: xcode11.3
-    - os: windows
 
 git:
   depth: 5

--- a/parser.mly
+++ b/parser.mly
@@ -192,7 +192,7 @@ withtyp :
   | withtyp WITH LPAR namelist typparamlist EQUAL exp RPAR
     { WithT($1, $4, funE($5, $7)@@span[ati 5; ati 7])@@at() }
   | withtyp WITH LPAR TYPE namelist typparamlist EQUAL typ RPAR
-    { WithT($1, $5, funE($6, TypE($8)@@ati 8)@@span[ati 6; ati 8])@@at() }
+    { WithT($1, $5, funE($6, typE($8)@@ati 8)@@span[ati 6; ati 8])@@at() }
 ;
 typ :
   | withtyp
@@ -207,6 +207,8 @@ typ :
     { recT(defaultTP $2, $4)@@at() }
   | LET bind IN typ
     { letT($2, $4)@@at() }
+  | FUN typparam typparamlist DARROW typ
+    { PathT(funE($2::$3, typE($5)@@ati 5)@@at())@@at() }
 ;
 typlist :
   | typ
@@ -226,7 +228,7 @@ opttypdef :
   |
     { TypT@@at() }
   | EQUAL typ
-    { EqT(TypE($2)@@ati 2)@@ati 2 }
+    { EqT(typE($2)@@ati 2)@@ati 2 }
 ;
 
 atdec :
@@ -269,7 +271,7 @@ atpathexp :
   | name
     { VarE($1)@@at() }
   | HOLE
-    { TypE(HoleT@@at())@@at() }
+    { typE(HoleT@@at())@@at() }
 ;
 apppathexp :
   | dotpathexp
@@ -277,7 +279,7 @@ apppathexp :
   | apppathexp dotpathexp
     { appE($1, $2)@@at() }
   | apppathexp attyp
-    { appE($1, TypE($2)@@ati 2)@@at() }
+    { appE($1, typE($2)@@ati 2)@@at() }
 ;
 infpathexp :
   | apppathexp
@@ -302,7 +304,7 @@ atexp :
   | name
     { VarE($1)@@at() }
   | HOLE
-    { TypE(HoleT@@at())@@at() }
+    { typE(HoleT@@at())@@at() }
   | PRIMITIVE TEXT
     { match Prim.fun_of_string $2 with
       | Some f -> PrimE(Prim.FunV f)@@at()
@@ -360,7 +362,7 @@ annexp :
   | infexp
     { $1 }
   | TYPE typ
-    { TypE($2)@@at() }
+    { typE($2)@@at() }
   | annexp annexp_op typ
     { $2($1, $3)@@at() }
 ;
@@ -438,7 +440,7 @@ atbind :
   | name
     { VarB($1, VarE($1.it@@at())@@at())@@at() }
   | typpat EQUAL typ
-    { VarB(fst $1, funE(snd $1, TypE($3)@@ati 3)@@at())@@at() }
+    { VarB(fst $1, funE(snd $1, typE($3)@@ati 3)@@at())@@at() }
   | ELLIPSIS exp
     { InclB($2)@@at() }
   | DO exp

--- a/regression.1ml
+++ b/regression.1ml
@@ -28,10 +28,10 @@ Equivalence: {
   transitivity 'a 'b 'c (ab: t a b) (bc: t b c) =
     wr fun (type p _) => un bc p << un ab p
   reflexivity = wr fun (type p _) => id
-  to eq a = un eq (fun (type x) => x) a
-  from 'a 'b (eq: t a b) b = un eq (fun (type b) => type b ~> a) id b
+  to eq a = un eq (type fun x => x) a
+  from 'a 'b (eq: t a b) b = un eq (type fun b => b ~> a) id b
   symmetry 'a 'b (eq: t a b) : t b a =
-    wr fun (type p _) => un eq (fun (type b) => type p b ~> p a) id
+    wr fun (type p _) => un eq (type fun b => p b ~> p a) id
 }
 
 ;;

--- a/syntax.ml
+++ b/syntax.ml
@@ -108,6 +108,11 @@ let opt fn (e, t) =
   | None -> e.it
   | Some t -> fn(e, t)
 
+let typE(t) =
+  match t.it with
+  | PathT(e) -> e.it
+  | _ -> TypE(t)
+
 (* Sugar *)
 
 let letE(b, e) =
@@ -122,7 +127,7 @@ let asVarE(e, n, k) =
     let x = var n@@e.at in
     letE(VarB(x, e)@@e.at, k x)
 
-let letT(b, t) = PathT(letE(b, TypE(t)@@t.at)@@span[b.at; t.at])
+let letT(b, t) = PathT(letE(b, typE(t)@@t.at)@@span[b.at; t.at])
 let letD(b, d) = InclD(letT(b, StrT(d)@@d.at)@@span[b.at; d.at])
 let letB(b, b') = InclB(letE(b, strE(b')@@b'.at)@@span[b.at; b'.at])
 
@@ -217,7 +222,7 @@ type pat = {bind: bind; infer: typ option; annot: typ option}
 
 let recT(p, t2) =
   let b, t1 = p.it in
-  let e = TypE(t2)@@t2.at in
+  let e = typE(t2)@@t2.at in
   let e' =
     match b.it with
     | VarB(x, {it = VarE({it = "$"})}) -> RecE(x, t1, e)


### PR DESCRIPTION
Uses of `TypE` are changed to use a "smart" `typE` constructor that peels away `PathT` from a type in expression contexts allowing non-base kind path expressions.

Adds syntax for type level `fun` path expressions with type parameters and type body.  Previously, one could write a value level `fun` expression

    fun (type t) => type t -> t

now one can write a type level `fun` expression

    type fun t => t -> t

The idea behind these changes is to make it so that the `type` keyword simply changes the default parameter kind from a value to a type and the bod kind from a value to a type.
