### PR TITLE
Add syntax for annotating the result type of `fun` expressions

### DIFF
--- a/parser.mly
+++ b/parser.mly
@@ -207,8 +207,8 @@ typ :
     { recT(defaultTP $2, $4)@@at() }
   | LET bind IN typ
     { letT($2, $4)@@at() }
-  | FUN typparam typparamlist DARROW typ
-    { PathT(funE($2::$3, typE($5)@@ati 5)@@at())@@at() }
+  | FUN typparam typparamlist bindanns_opt DARROW typ
+    { PathT(funE($2::$3, $4(typE($6)@@ati 6))@@at())@@at() }
 ;
 typlist :
   | typ
@@ -379,8 +379,8 @@ exp :
     { seqE($1, $3)@@at() }
   | inexp
     { $1 }
-  | FUN param paramlist DARROW exp
-    { funE($2::$3, $5)@@at() }
+  | FUN param paramlist bindanns_opt DARROW exp
+    { funE($2::$3, $4($6))@@at() }
   | REC atpat DARROW exp
     { recE(defaultP $2, $4)@@at() }
 ;

--- a/talk.1ml
+++ b/talk.1ml
@@ -101,22 +101,22 @@ do map : 'a -> 'b -> (m: type -> type) -> (M: MONAD m) -> (a ~> b) ~> m a ~> m b
 
 ;; Objects
 
-type point' self = {
-  getX : () ~> int
-  getY : () ~> int
-  move : int ~> int ~> self
+...rec {type point} => {
+  type point = {
+    getX : () ~> int
+    getY : () ~> int
+    move : int ~> int ~> point
+  }
 }
-type recpoint = rec (x : type) => point' x
-type point = point' recpoint
 
-newpoint = rec (newpoint : int -> int -> point) => fun x y => {
+newpoint = rec (newpoint : int -> int -> point) => fun x y :@ point => {
   getX () = x
   getY () = y
-  move dx dy :@ recpoint = newpoint (x + dx) (y + dy)
+  move dx dy = newpoint (x + dx) (y + dy)
 }
 
 p = newpoint 3 4
-p' @: recpoint = p.move 1 2
+p' @: point = (p @: point).move 1 2
 do Int.print (p'.getX ())
 do print " "
 do Int.print (p'.getY ())


### PR DESCRIPTION
Previously you would write:

    fun (; params ;) => (; body ;) : t

Now you can also write:

    fun (; params ;) : t => (; body ;)