### PR TITLE
Change to allow atomic types as arguments of infix ops

### DIFF
--- a/parser.mly
+++ b/parser.mly
@@ -180,15 +180,9 @@ attyp :
   | LPAR EQUAL exp RPAR
     { EqT($3)@@at() }
 ;
-apptyp :
-  | attyp
-    { $1 }
-  | pathexp
-    { PathT($1)@@at() }
-;
 withtyp :
-  | apptyp
-    { $1 }
+  | infpathexp
+    { pathT($1)@@at() }
   | withtyp WITH LPAR namelist typparamlist EQUAL exp RPAR
     { WithT($1, $4, funE($5, $7)@@span[ati 5; ati 7])@@at() }
   | withtyp WITH LPAR TYPE namelist typparamlist EQUAL typ RPAR
@@ -282,16 +276,18 @@ apppathexp :
     { appE($1, typE($2)@@ati 2)@@at() }
 ;
 infpathexp :
-  | apppathexp
+  | apppathexp_or_typ
     { $1 }
-  | sym apppathexp
+  | sym apppathexp_or_typ
     { appE(VarE($1)@@ati(1), $2)@@at() }
-  | infpathexp sym apppathexp
+  | infpathexp sym apppathexp_or_typ
     { appE(appE(VarE($2)@@ati(2), $1)@@at(), $3)@@at() }
 ;
-pathexp :
-  | infpathexp
+apppathexp_or_typ :
+  | apppathexp
     { $1 }
+  | attyp
+    { typE($1)@@at() }
 ;
 
 dotexp :

--- a/regression.1ml
+++ b/regression.1ml
@@ -238,6 +238,8 @@ Alt = {
 }
 (|) = Alt.|
 
+type AnAlt = {x: int} | {y: bool}
+
 infix_type_pat 'a 'b (type _ | _) (x: a | b) = x
 infix_type_dec 'a 'b ({type _ | _}) (x: a | b) = x
 

--- a/syntax.ml
+++ b/syntax.ml
@@ -114,6 +114,11 @@ let typE(t) =
   | PathT(e) -> e.it
   | _ -> TypE(t)
 
+let pathT(e) =
+  match e.it with
+  | TypE(t) -> t.it
+  | _ -> PathT(e)
+
 (* Sugar *)
 
 let letE(b, e) =


### PR DESCRIPTION
This adds another smart constructor `pathT` that peels away `TypE`.

What is still disallowed is application of atomic type to another atomic type.