### PR TITLE
Change to infer type binds of base kind

### DIFF
--- a/prelude/index.1ml
+++ b/prelude/index.1ml
@@ -79,7 +79,7 @@ List = {
 
 ;;
 
-Zero :> {type t} = {type t = {}}
+Zero :> {type t} = {}
 
 ;;
 

--- a/regression.1ml
+++ b/regression.1ml
@@ -2,6 +2,13 @@ local import "basis"
 
 ;;
 
+assert b =
+  if not b then
+    Text.print "Assertion failed"
+    System.exit 1
+
+;;
+
 record_inference x = x.works_a_little
 
 ;;
@@ -49,6 +56,16 @@ Equivalence: {
   symmetry 'a 'b (eq: t a b) : t b a =
     wr fun (type p _) => un eq (type fun b => p b ~> p a) id
 }
+
+;;
+
+type MONOID = {type t, empty: t, (++): t -> t ~> t}
+cat (M: MONOID) = List.foldl M.++ M.empty
+do assert (cat {empty = 0, (++) = (+)} (40 :: (2 :: nil)) == 42)
+
+Poly: {type t} = {} ;; Poly 'x = {type t = x}
+do 1: Poly.t
+do "": Poly.t
 
 ;;
 
@@ -274,7 +291,6 @@ N :> {
   type Z
   type S _
 } = {
-  type Z   = {}
   type S _ = {}
 }
 

--- a/types.ml
+++ b/types.ml
@@ -118,6 +118,22 @@ let rec project_typ ls t =
   | _ -> raise Not_found
 
 
+(* *)
+
+let is_base_typ = function
+  | VarT(a, k) -> false
+  | PrimT(t) -> false
+  | StrT(r) -> false
+  | FunT(aks, td, tc, e) -> false
+  | TypT(s) -> true
+  | WrapT(s) -> false
+  | LamT(aks, t) -> false
+  | AppT(t, ts) -> false
+  | TupT(r) -> false
+  | DotT(t, l) -> false
+  | RecT(ak, t) -> false
+  | InferT(z) -> false
+
 (* Size check *)
 
 let undecidable_flag = ref false

--- a/types.mli
+++ b/types.mli
@@ -99,6 +99,9 @@ val diff_row : 'a row -> 'a row -> 'a row
 
 val project_typ : lab list -> typ -> typ (* raise Not_found *)
 
+(* *)
+
+val is_base_typ : typ -> bool
 
 (* Size check *)
 


### PR DESCRIPTION
In a context requiring a `type id` binding of a small type, subtyping now effectively implicitly inserts a `type id = _` binding in case there is no binding of `id`.

For example, given

    type MONOID = {
      type t
      empty: t
      (++): t -> t ~> t
    }

    cat (M: MONOID) = List.foldr M.++ M.empty

one can now write

    cat {empty = 0, (++) = (+)} (40 :: (2 :: nil))

    cat {empty = "", (++)} ("Hello, " :: ("world!" :: nil))

and 1ML will infer the missing `type t` bindings.

Related [card](https://github.com/orgs/1ml-prime/projects/1#card-36187562).