### PR TITLE
Change to infer transparent type binds

### DIFF
--- a/erase.ml
+++ b/erase.ml
@@ -53,3 +53,23 @@ let erase_env env =
   let env2' = VarSet.fold (fun x env' ->
     IL.add_val x (erase_typ (lookup_val x env)) env') (domain_val env) env1' in
   env2'
+
+let rec erase_tycon = function
+  | FunT(aks1, td, ExT(aks2, tc), e) ->
+    (match e with
+    | Explicit Pure | Implicit ->
+      let e = IL.genE(erase_bind aks2, erase_tycon tc) in
+      IL.genE(erase_bind aks1, IL.LamE("_", erase_typ td, e))
+    | Explicit Impure ->
+      assert false)
+  | TypT(s) -> IL.LamE("_", erase_extyp s, IL.TupE[])
+  | VarT(_, _)
+  | PrimT(_)
+  | StrT(_)
+  | WrapT(_)
+  | LamT(_, _)
+  | AppT(_, _)
+  | DotT(_, _)
+  | TupT(_)
+  | RecT(_, _)
+  | InferT(_) -> assert false

--- a/erase.mli
+++ b/erase.mli
@@ -8,3 +8,5 @@ val erase_extyp : Types.extyp -> Fomega.typ
 val erase_bind :
   (Types.var * Types.kind) list -> (Fomega.var * Fomega.kind) list
 val erase_env : Env.env -> Fomega.env
+
+val erase_tycon : Types.typ -> Fomega.exp

--- a/regression.1ml
+++ b/regression.1ml
@@ -69,6 +69,11 @@ do "": Poly.t
 
 ;;
 
+ManifestTycon: {type t (i: {}) 'z (m: {type t, x: t}) = (m.t, z, m.t)} = {}
+do ManifestTycon.t {} {type t = int, x = 1}
+
+;;
+
 AmateurOptics = {
   type FUNCTOR = {
     type t a
@@ -246,12 +251,9 @@ in {
 
 ;;
 
-Alt = {
-  ...Alt
-  type a | b = alt a b
-} : {
+Alt = Alt : {
   ...(= Alt)
-  type _ | _
+  type a | b = alt a b
 }
 (|) = Alt.|
 


### PR DESCRIPTION
In a context requiring a binding of a transparent type constructor, subtyping now implicitly inserts the type binding in case it is missing.

For example, given

    type PAIR = {type t x y = (x, y)}

one can now write

    Pair: PAIR = {}

and 1ML will infer the missing `type t` binding.

Related [card](https://github.com/orgs/1ml-prime/projects/1#card-36296436).