### PR TITLE
Change to infer base & transparent type constructors and structures

### DIFF
--- a/erase.ml
+++ b/erase.ml
@@ -53,23 +53,3 @@ let erase_env env =
   let env2' = VarSet.fold (fun x env' ->
     IL.add_val x (erase_typ (lookup_val x env)) env') (domain_val env) env1' in
   env2'
-
-let rec erase_tycon = function
-  | FunT(aks1, td, ExT(aks2, tc), e) ->
-    (match e with
-    | Explicit Pure | Implicit ->
-      let e = IL.genE(erase_bind aks2, erase_tycon tc) in
-      IL.genE(erase_bind aks1, IL.LamE("_", erase_typ td, e))
-    | Explicit Impure ->
-      assert false)
-  | TypT(s) -> IL.LamE("_", erase_extyp s, IL.TupE[])
-  | VarT(_, _)
-  | PrimT(_)
-  | StrT(_)
-  | WrapT(_)
-  | LamT(_, _)
-  | AppT(_, _)
-  | DotT(_, _)
-  | TupT(_)
-  | RecT(_, _)
-  | InferT(_) -> assert false

--- a/erase.mli
+++ b/erase.mli
@@ -8,5 +8,3 @@ val erase_extyp : Types.extyp -> Fomega.typ
 val erase_bind :
   (Types.var * Types.kind) list -> (Fomega.var * Fomega.kind) list
 val erase_env : Env.env -> Fomega.env
-
-val erase_tycon : Types.typ -> Fomega.exp

--- a/import.ml
+++ b/import.ml
@@ -15,10 +15,10 @@ let (<|>) xO uxO =
   | some -> some
 
 let finish path =
-  if Lib.Sys.file_exists_at path then
-    Some path
-  else
-    None
+  if Lib.Sys.file_exists_at path
+     || Lib.Sys.file_exists_at (Lib.Filename.replace_ext mod_ext sig_ext path)
+  then Some path
+  else None
 
 let complete path =
   if Lib.String.is_suffix mod_ext path then

--- a/lib.ml
+++ b/lib.ml
@@ -98,4 +98,19 @@ struct
     match o with
     | Some v -> v
     | None -> default
+
+  let map xy = function
+    | None -> None
+    | Some x -> Some (xy x)
+
+  let bind xO xyO =
+    match xO with
+    | None -> None
+    | Some x -> xyO x
+
+  let traverse xyO xs =
+    let rec loop ys = function
+      | [] -> Some ys
+      | x::xs -> bind (xyO x) @@ fun y -> loop (y::ys) xs in
+    loop [] xs |> map List.rev
 end

--- a/lib.mli
+++ b/lib.mli
@@ -40,4 +40,7 @@ end
 module Option :
 sig
   val value: 'a option -> default: 'a -> 'a
+  val map: ('a -> 'b) -> 'a option -> 'b option
+  val bind: 'a option -> ('a -> 'b option) -> 'b option
+  val traverse: ('a -> 'b option) -> 'a list -> 'b list option
 end

--- a/main.ml
+++ b/main.ml
@@ -32,7 +32,8 @@ let load mod_path fake_path real_path =
     let source = really_input_string f size in
     close_in f;
     source in
-  let mod_source = load_file mod_path in
+  let mod_source =
+    if Lib.Sys.file_exists_at mod_path then load_file mod_path else "" in
   let sig_path = Lib.Filename.replace_ext Import.mod_ext Import.sig_ext mod_path in
   if Lib.Sys.file_exists_at sig_path then
     Sealed (mod_source, load_file sig_path)

--- a/prelude/index.1ml
+++ b/prelude/index.1ml
@@ -79,21 +79,6 @@ List = {
 
 ;;
 
-Zero :> {type t} = {}
-
-;;
-
-alt = Alt.t
-bool = Bool.t
-char = Char.t
-int = Int.t
-list = List.t
-opt = Opt.t
-text = Text.t
-zero = Zero.t
-
-;;
-
 (%) = Int.%
 (*) = Int.*
 (+) = Int.+

--- a/sub.ml
+++ b/sub.ml
@@ -57,23 +57,44 @@ let rec is_transparent_typ env = function
   | RecT(_, _)
   | InferT(_) -> true
 
-let rec is_transparent_tycon env = function
-  | FunT(aks1, td, ExT(aks2, tc), e) ->
+let rec infer_bind isCon env = function
+  | VarT(_, _) -> None
+  | PrimT(_) -> None
+  | StrT(tr) ->
+    tr
+    |> Lib.Option.traverse (fun (l, t) ->
+       infer_bind isCon env t |> Lib.Option.map (fun i -> (l, i)))
+    |> Lib.Option.map (fun ir ->
+       (StrT(ir |> List.map (fun (l, (t, _, _)) -> (l, t))),
+        ir |> List.map (fun (_, (_, zs, _)) -> zs) |> List.concat,
+        IL.TupE(ir |> List.map (fun (l, (_, _, e)) -> (l, e)))))
+  | FunT(aksd, td, ExT(aksc, tc), e) ->
     (match e with
+    | Explicit Impure ->
+      None
     | Explicit Pure | Implicit ->
-      is_transparent_tycon (add_typs aks2 (add_typs aks1 env)) tc
-    | Explicit Impure -> false)
-  | TypT(ExT(aks, t)) -> is_transparent_typ (add_typs aks env) t
-  | VarT(_, _)
-  | PrimT(_)
-  | StrT(_)
-  | WrapT(_)
-  | LamT(_, _)
-  | AppT(_, _)
-  | TupT(_)
-  | DotT(_, _)
-  | RecT(_, _)
-  | InferT(_) -> false
+      infer_bind true (add_typs aksc (add_typs aksd env)) tc
+      |> Lib.Option.map (fun (tc, zs, ec) ->
+         (FunT(aksd, td, ExT(aksc, tc), e),
+          zs,
+          let ec = IL.genE(erase_bind aksc, ec) in
+          IL.genE(erase_bind aksd, IL.LamE("_", erase_typ td, ec)))))
+  | TypT(ExT(aks, t) as s) as t1 ->
+    if is_transparent_typ (add_typs aks env) t then
+      Some (t1, [], IL.LamE("_", erase_extyp s, IL.TupE[]))
+    else if not isCon && is_small_typ t1 then
+      let t, zs = guess_typ (Env.domain_typ env) BaseK in
+      let s = ExT([], t) in
+      Some (TypT(s), zs, IL.LamE("_", erase_extyp s, IL.TupE[]))
+    else
+      None
+  | WrapT(_) -> None
+  | LamT(_, _) -> None
+  | AppT(_, _) -> None
+  | TupT(_) -> None
+  | DotT(_, _) -> None
+  | RecT(_, _) -> None
+  | InferT(_) -> None
 
 (* Materialization *)
 
@@ -125,17 +146,12 @@ let lift_warn at t env zs =
 
 (* Subtyping *)
 
-let extract_bind env tr1 l t2 =
+let extract_bind infer_binds env tr1 l t2 =
   try List.assoc l tr1, [], fun f l x -> IL.AppE(f, IL.DotE(x, l)) with
   | Not_found ->
-    if is_base_typ t2 && is_small_typ t2 then
-      let t, zs = guess_typ (Env.domain_typ env) BaseK in
-      let t1 = TypT(ExT([], t)) in
-      t1, zs, fun f _ _ -> IL.AppE(f, erase_tycon t1)
-    else if is_transparent_tycon env t2 then
-      t2, [], fun f _ _ -> IL.AppE(f, erase_tycon t2)
-    else
-      raise (Sub (Struct(l, Missing)))
+    match if infer_binds then infer_bind false env t2 else None with
+    | None -> raise (Sub (Struct(l, Missing)))
+    | Some (t, zs, e) -> t, zs, fun f _ _ -> IL.AppE(f, e)
 
 let resolve_typ z t =
   Trace.sub (lazy ("[resolve_typ] z = " ^ string_of_norm_typ (InferT(z))));
@@ -153,7 +169,7 @@ let rec psubst p t =
   | AppT(p', ts) -> psubst p' (LamT(List.map unvarT ts, t))
   | _ -> assert false
 
-let rec sub_typ env t1 t2 ps =
+let rec sub_typ infer_binds env t1 t2 ps =
   Trace.sub (lazy ("[sub_typ] t1 = " ^ string_of_norm_typ t1));
   Trace.sub (lazy ("[sub_typ] t2 = " ^ string_of_norm_typ t2));
   Trace.sub (lazy ("[sub_typ] ps = " ^
@@ -163,7 +179,7 @@ let rec sub_typ env t1 t2 ps =
     match norm_typ t1, freshen_typ env (norm_typ t2) with
     | t1, FunT(aks21, t21, ExT(aks22, t22), Implicit) ->
       assert (aks22 = []);
-      let ts, zs, f = sub_typ (add_typs aks21 env) t1 t22 ps in
+      let ts, zs, f = sub_typ infer_binds (add_typs aks21 env) t1 t22 ps in
       List.map (fun t -> LamT(aks21, t)) ts, lift env zs,
       IL.genE(erase_bind aks21, (IL.LamE("y", erase_typ t21, IL.AppE(f, e1))))
 
@@ -171,7 +187,7 @@ let rec sub_typ env t1 t2 ps =
       assert (aks12 = []);
       let ts1, zs1 = guess_typs (Env.domain_typ env) aks11 in
       let t1' = subst_typ (subst aks11 ts1) t12 in
-      let ts2, zs2, f = sub_typ env t1' t2 ps in
+      let ts2, zs2, f = sub_typ infer_binds env t1' t2 ps in
       ts2, zs1 @ zs2,
       IL.AppE(f, IL.AppE(IL.instE(e1, List.map erase_typ ts1),
         materialize_typ (subst_typ (subst aks11 ts1) t11)))
@@ -188,7 +204,7 @@ let rec sub_typ env t1 t2 ps =
       )
 
     | StrT(tr1), StrT(tr2) ->
-      let ts, zs, fs = sub_row env tr1 tr2 ps in
+      let ts, zs, fs = sub_row infer_binds env tr1 tr2 ps in
       ts, zs,
       IL.TupE(List.map2 (fun (l, _) f -> l, f l e1) tr2 fs)
 
@@ -200,11 +216,11 @@ let rec sub_typ env t1 t2 ps =
       if p1 = Impure && p2 = Pure then raise (Sub (FunEffect(p1, p2)));
       let env' = add_typs aks2 env in
       let ts1, zs1, f1 =
-        try sub_typ env' t21 t11 (varTs aks1) with Sub e ->
+        try sub_typ infer_binds env' t21 t11 (varTs aks1) with Sub e ->
           raise (Sub (FunParam e)) in
       let ps' = List.map (fun p -> AppT(p, varTs aks2)) ps in
       let ts2, zs2, f2 =
-        try sub_extyp env' (subst_extyp (subst aks1 ts1) s1) s2 ps'
+        try sub_extyp infer_binds env' (subst_extyp (subst aks1 ts1) s1) s2 ps'
         with Sub e -> raise (Sub (FunResult e)) in
       List.map (fun t -> LamT(aks2, t)) ts2, lift env (zs1 @ zs2),
       IL.genE(erase_bind aks2, (IL.LamE("y", erase_typ t21,
@@ -213,7 +229,8 @@ let rec sub_typ env t1 t2 ps =
 
     | WrapT(s1), WrapT(s2) ->
       let _, zs, f =
-        try sub_extyp env s1 s2 [] with Sub e -> raise (Sub (Wrap e)) in
+        try sub_extyp infer_binds env s1 s2 []
+        with Sub e -> raise (Sub (Wrap e)) in
       [], zs, IL.TupE["wrap", IL.AppE(f, IL.DotE(e1, "wrap"))]
 
     | AppT(t1', ts1), AppT(t2', ts2) ->
@@ -255,7 +272,7 @@ let rec sub_typ env t1 t2 ps =
     | InferT(z) as t1, (TypT(_) as t2) ->
       let t11, zs1 = guess_typ (Env.domain_typ env) BaseK in
       let t1' = TypT(ExT([], t11)) in
-      let ts, zs2, f = sub_typ env t1' t2 ps in
+      let ts, zs2, f = sub_typ infer_binds env t1' t2 ps in
       if not (resolve_typ z t1') then raise (Sub (Mismatch(t1, t2)));
       ts, zs1 @ zs2, IL.AppE(f, e1)
 
@@ -264,7 +281,7 @@ let rec sub_typ env t1 t2 ps =
       let tzsr = map_row (fun _ -> guess_typ (Env.domain_typ env) BaseK) tr2 in
       let t1' = StrT(map_row fst tzsr) in
       let zs1 = List.concat (List.map snd (List.map snd tzsr)) in
-      let ts, zs2, f = sub_typ env t1' t2 ps in
+      let ts, zs2, f = sub_typ infer_binds env t1' t2 ps in
       if not (resolve_typ z t1') then raise (Sub (Mismatch(t1, t2)));
       ts, zs1 @ zs2, IL.AppE(f, e1)
 
@@ -272,7 +289,7 @@ let rec sub_typ env t1 t2 ps =
       let t11, zs1 = guess_typ (Env.domain_typ env) BaseK in
       let t12, zs2 = guess_typ (Env.domain_typ env) BaseK in
       let t1' = FunT([], t11, ExT([], t12), Explicit Impure) in
-      let ts, zs3, f = sub_typ env t1' t2 ps in
+      let ts, zs3, f = sub_typ infer_binds env t1' t2 ps in
       if not (resolve_typ z t1') then raise (Sub (Mismatch(t1, t2)));
       ts, zs1 @ zs2 @ zs3, IL.AppE(f, e1)
 
@@ -283,7 +300,7 @@ let rec sub_typ env t1 t2 ps =
     | TypT(_) as t1, (InferT(z) as t2) ->
       let t21, zs1 = guess_typ (Env.domain_typ env) BaseK in
       let t2' = TypT(ExT([], t21)) in
-      let ts, zs2, f = sub_typ env t1 t2' ps in
+      let ts, zs2, f = sub_typ infer_binds env t1 t2' ps in
       if not (resolve_typ z t2') then raise (Sub (Mismatch(t1, t2)));
       ts, zs1 @ zs2, IL.AppE(f, e1)
 
@@ -292,7 +309,7 @@ let rec sub_typ env t1 t2 ps =
       let tzsr = map_row (fun _ -> guess_typ (Env.domain_typ env) BaseK) tr1 in
       let t2' = StrT(map_row fst tzsr) in
       let zs1 = List.concat (List.map snd (List.map snd tzsr)) in
-      let ts, zs2, f = sub_typ env t1 t2' ps in
+      let ts, zs2, f = sub_typ infer_binds env t1 t2' ps in
       if not (resolve_typ z t2') then raise (Sub (Mismatch(t1, t2)));
       ts, zs1 @ zs2, IL.AppE(f, e1)
 
@@ -300,7 +317,7 @@ let rec sub_typ env t1 t2 ps =
       let t21, zs1 = guess_typ (Env.domain_typ env) BaseK in
       let t22, zs2 = guess_typ (Env.domain_typ env) BaseK in
       let t2' = FunT([], t21, ExT([], t22), Explicit Impure) in
-      let ts, zs3, f = sub_typ env t1 t2' ps in
+      let ts, zs3, f = sub_typ infer_binds env t1 t2' ps in
       if not (resolve_typ z t2') then raise (Sub (Mismatch(t1, t2)));
       ts, zs1 @ zs2 @ zs3, IL.AppE(f, e1)
 
@@ -320,58 +337,62 @@ let rec sub_typ env t1 t2 ps =
   Trace.sub (lazy ("[sub_typ] done x -> " ^ IL.string_of_exp e));
   ts, zs, IL.LamE("x", erase_typ t1, e)
 
-and sub_extyp env s1 s2 ps =
+and sub_extyp infer_binds env s1 s2 ps =
   Trace.sub (lazy ("[sub_extyp] s1 = " ^ string_of_norm_extyp s1));
   Trace.sub (lazy ("[sub_extyp] s2 = " ^ string_of_norm_extyp s2));
   let ExT(aks2, t2) = freshen_extyp env s2 in
   let ExT(aks1, t1) = freshen_extyp (add_typs aks2 env) s1 in
   match aks1, aks2 with
   | [], [] ->
-    sub_typ env t1 t2 ps
+    sub_typ infer_binds env t1 t2 ps
   | _ ->
-    let ts, zs, f = sub_typ (add_typs aks1 env) t1 t2 (varTs aks2) in
+    let ts, zs, f =
+      sub_typ infer_binds (add_typs aks1 env) t1 t2 (varTs aks2) in
     [], lift env zs,
     IL.LamE("x", erase_extyp s1,
       IL.openE(IL.VarE("x"), List.map fst aks1, "y",
         IL.packE(List.map erase_typ ts,
           IL.AppE(f, IL.VarE("y")), erase_extyp s2)))
 
-and sub_row env tr1 tr2 ps =
+and sub_row infer_binds env tr1 tr2 ps =
   match tr2 with
   | [] ->
     [], [], []
   | (l, t2)::tr2' ->
     Trace.sub (lazy ("[sub_row] l = " ^ l));
-    let t1, zs, app = extract_bind env tr1 l t2 in
+    let t1, zs, app = extract_bind infer_binds env tr1 l t2 in
     let ts1, zs1, f =
-      try sub_typ env t1 t2 ps with
+      try sub_typ infer_binds env t1 t2 ps with
       | Sub e -> raise (Sub (Struct(l, e))) in
     let su = List.map2 psubst (Lib.List.take (List.length ts1) ps) ts1 in
     let ps' = Lib.List.drop (List.length ts1) ps in
-    let ts2, zs2, fs = sub_row env tr1 (subst_row su tr2') ps' in
+    let ts2, zs2, fs = sub_row infer_binds env tr1 (subst_row su tr2') ps' in
     ts1 @ ts2, zs @ zs1 @ zs2, app f::fs
 
 and equal_typ env t1 t2 =
   Trace.sub (lazy ("[equal_typ] t1 = " ^ string_of_norm_typ t1));
   Trace.sub (lazy ("[equal_typ] t2 = " ^ string_of_norm_typ t2));
   let _, zs1, _ =
-    try sub_typ env t1 t2 [] with Sub e -> raise (Sub (Left e)) in
+    try sub_typ false env t1 t2 [] with Sub e -> raise (Sub (Left e)) in
   let _, zs2, _ =
-    try sub_typ env t2 t1 [] with Sub e -> raise (Sub (Right e)) in
+    try sub_typ false env t2 t1 [] with Sub e -> raise (Sub (Right e)) in
   zs1 @ zs2
 
 and equal_extyp env s1 s2 =
   Trace.sub (lazy ("[equal_extyp] s1 = " ^ string_of_norm_extyp s1));
   Trace.sub (lazy ("[equal_extyp] s2 = " ^ string_of_norm_extyp s2));
   let _, zs1, _ =
-    try sub_extyp env s1 s2 [] with Sub e -> raise (Sub (Left e)) in
+    try sub_extyp false env s1 s2 [] with Sub e -> raise (Sub (Left e)) in
   let _, zs2, _ =
-    try sub_extyp env s2 s1 [] with Sub e -> raise (Sub (Right e)) in
+    try sub_extyp false env s2 s1 [] with Sub e -> raise (Sub (Right e)) in
   zs1 @ zs2
 
 and equal_row env tr1 tr2 ps =
   let _, zs1, _ =
-    try sub_row env tr1 tr2 ps with Sub e -> raise (Sub (Left e)) in
+    try sub_row false env tr1 tr2 ps with Sub e -> raise (Sub (Left e)) in
   let _, zs2, _ =
-    try sub_row env tr2 tr1 ps with Sub e -> raise (Sub (Right e)) in
+    try sub_row false env tr2 tr1 ps with Sub e -> raise (Sub (Right e)) in
   zs1 @ zs2
+
+let sub_typ = sub_typ true
+let sub_extyp = sub_extyp true

--- a/types.ml
+++ b/types.ml
@@ -118,22 +118,6 @@ let rec project_typ ls t =
   | _ -> raise Not_found
 
 
-(* *)
-
-let is_base_typ = function
-  | TypT(_) -> true
-  | VarT(_, _)
-  | PrimT(_)
-  | StrT(_)
-  | FunT(_, _, _, _)
-  | WrapT(_)
-  | LamT(_, _)
-  | AppT(_, _)
-  | TupT(_)
-  | DotT(_, _)
-  | RecT(_, _)
-  | InferT(_) -> false
-
 (* Size check *)
 
 let undecidable_flag = ref false

--- a/types.mli
+++ b/types.mli
@@ -99,9 +99,6 @@ val diff_row : 'a row -> 'a row -> 'a row
 
 val project_typ : lab list -> typ -> typ (* raise Not_found *)
 
-(* *)
-
-val is_base_typ : typ -> bool
 
 (* Size check *)
 


### PR DESCRIPTION
Subtyping now implicitly inserts bindings that can be fully inferred from their type.  This roughly includes types of base kind, transparent type constructors (which are pure functions) and structures containing those.

    inferrable : { name: inferrable }
               | abstract type
               | _ -> transparent

    transparent : { name: transparent }
                | transparent type
                | _ -> transparent

So, in a context requiring a `type id` binding of a small type, subtyping now effectively implicitly inserts a `type id = _` binding in case there is no binding of `id`.

For example, given

    type MONOID = {
      type t
      empty: t
      (++): t -> t ~> t
    }

    cat (M: MONOID) = List.foldr M.++ M.empty

one can now write

    cat {empty = 0, (++) = (+)} (40 :: (2 :: nil))

    cat {empty = "", (++)} ("Hello, " :: ("world!" :: nil))

and 1ML will infer the missing `type t` bindings.

Also, in a context requiring a binding of a transparent type constructor, subtyping now implicitly inserts the type binding in case it is missing.

For example, given

    type PAIR = {type t x y = (x, y)}

one can now write

    Pair: PAIR = {}

and 1ML will infer the missing `type t` binding.

The import mechanism has now also been relaxed to allow a module consisting only of a signature file.  In such a case the module (or structure) file is considered empty and the compiler will attempt to infer the bindings.