### PR TITLE
Change to accept syms without parens and to declare multiple names

### DIFF
--- a/basis/index.1ml
+++ b/basis/index.1ml
@@ -6,7 +6,7 @@ List = import "./list"
 
 type ORD = {
   type t
-  (<=) : t -> t ~> Bool.t
+  <= : t -> t ~> Bool.t
 }
 
 type SET = {

--- a/examples/fc.1ml
+++ b/examples/fc.1ml
@@ -38,7 +38,7 @@ GADTs = {
 AssociatedTypes = {
   type EQ = {
     type t
-    (==): t -> t -> bool
+    == : t -> t -> bool
   }
 
   type COLLECTS = {

--- a/examples/leibniz.1mls
+++ b/examples/leibniz.1mls
@@ -3,7 +3,7 @@ type t a b
 type a ~ b = t a b
 
 id 'a: a ~ a                           ;; Reflexivity
-(<<) 'a 'b 'c: b ~ c -> a ~ b -> a ~ c ;; Transitivity
+<< 'a 'b 'c: b ~ c -> a ~ b -> a ~ c   ;; Transitivity
 invert 'a 'b: a ~ b -> b ~ a           ;; Symmetry
 
 to   'a 'b: a ~ b -> a -> b

--- a/examples/type-level.1ml
+++ b/examples/type-level.1ml
@@ -28,8 +28,8 @@ TypeLevel: {
 
     not: t -> t
 
-    (&&&): t -> t -> t
-    (|||): t -> t -> t
+    &&& : t -> t -> t
+    ||| : t -> t -> t
 
     equals: t -> t -> t
   }
@@ -56,15 +56,15 @@ TypeLevel: {
 
     succ: t -> t
 
-    (+): t -> t -> t
-    (*): t -> t -> t
+    + : t -> t -> t
+    * : t -> t -> t
   }
 
   List: {
     type t = type -> (type _ _ _) -> type
 
     nil: t
-    (::): type -> t -> t
+    :: : type -> t -> t
 
     map: (type _ _) -> t -> t
 

--- a/lexer.mll
+++ b/lexer.mll
@@ -253,7 +253,7 @@ let escape = ['n''t''\\''\'''\"']
 let character = [^'"''\\''\n'] | '\\'escape
 
 let num = digit+
-let name = (letter | '_') (letter | digit | '_' | tick)*
+let word = (letter | '_') (letter | digit | '_' | tick)*
 let text = '"'character*'"'
 let char = '\''character '\''
 
@@ -298,7 +298,7 @@ rule token = parse
   | "}" { RBRACE }
   | "," { COMMA }
   | ";" { SEMI }
-  | name as s { NAME s }
+  | word as s { WORD s }
   | symbol* as s { SYM s }
   | num as s { NUM (convert_num s) }
   | char as s { CHAR (convert_char s) }

--- a/paper.1ml
+++ b/paper.1ml
@@ -60,9 +60,9 @@ type EQ = {
 type MAP = {
   type key
   type map a
-  empty (a : type) : map a
-  add (a : type) : key -> a -> map a ~> map a
-  lookup (a : type) : key -> map a ~> opt a
+  empty : (a : type) -> map a
+  add : (a : type) -> key -> a -> map a ~> map a
+  lookup : (a : type) -> key -> map a ~> opt a
 }
 
 Map (Key : EQ) :> MAP with (type key = Key.t) = {
@@ -101,8 +101,8 @@ entries (c : type) (C : COLL c) (xs : c) : list (C.key, C.val) =
   List.map (C.keys xs) (fun (k : C.key) => (k, caseopt (C.lookup xs k) bot id))
 
 type MONAD (m : type -> type) = {
-  return (a : type) : a ~> m a
-  bind (a : type) (b : type) : m a -> (a ~> m b) ~> m b
+  return : (a : type) -> a ~> m a
+  bind : (a : type) -> (b : type) -> m a -> (a ~> m b) ~> m b
 }
 map (a : type) (b : type) (m : type -> type) (M : MONAD m) (f : a ~> b) (mx : m a) =
   M.bind a b mx (fun (x : a) => M.return b (f x))  ;; : m b

--- a/prelude/index.1ml
+++ b/prelude/index.1ml
@@ -58,7 +58,7 @@ List = {
   ...rec {type t _} => {type t x = Opt.t (x, t x)}
   nil = Opt.none
   hd :: tl = Opt.some (hd, tl)
-  case {nil, (::)} = Opt.case {
+  case {nil, ::} = Opt.case {
     none = nil
     some (hd, tl) = hd :: tl
   }
@@ -66,9 +66,9 @@ List = {
 
 {either, inl, inr, plus} = Alt
 {false, not, true} = Bool
-{(<<), (<|), (>>), (|>), bot, const, curry, flip, id, uncurry} = Fun
-{(%), (*), (+), (-), (/), (<), (<=), (<>), (==), (>), (>=)} = Int
-{(::), nil} = List
+{<<, <|, >>, |>, bot, const, curry, flip, id, uncurry} = Fun
+{%, *, +, -, /, <, <=, <>, ==, >, >=} = Int
+{::, nil} = List
 {none, some} = Opt
 {cross, fork, fst, snd} = Pair
-{(++), print} = Text
+{++, print} = Text

--- a/prelude/index.1mls
+++ b/prelude/index.1mls
@@ -11,18 +11,15 @@ Alt: {
 
 Bool: {
   type t = bool
-  (==): t -> t -> bool
-  (<>): t -> t -> bool
-  true: t
-  false: t
+  <> == : t -> t -> bool
+  false true: t
   not: t -> t
   toText: t -> text
 }
 
 Char: {
   type t = char
-  (==): t -> t -> bool
-  (<>): t -> t -> bool
+  <> == : t -> t -> bool
   toInt: t -> int
   fromInt: int -> t
   print: t ~> {}
@@ -36,25 +33,16 @@ Fun: {
   curry 'a 'b 'c: ((a, b) ~> c) -> a -> b ~> c
   uncurry 'a 'b 'c: (a ~> b ~> c) -> (a, b) ~> c
   flip 'a 'b 'c: (a ~> b ~> c) -> b -> a ~> c
-  (<<) 'a 'b 'c: (b ~> c) -> (a ~> b) -> a ~> c
-  (>>) 'a 'b 'c: (a ~> b) -> (b ~> c) -> a ~> c
-  (<|) 'a 'b: (a ~> b) -> a ~> b
-  (|>) 'a 'b: a -> (a ~> b) ~> b
+  << 'a 'b 'c: (b ~> c) -> (a ~> b) -> a ~> c
+  >> 'a 'b 'c: (a ~> b) -> (b ~> c) -> a ~> c
+  <| 'a 'b: (a ~> b) -> a ~> b
+  |> 'a 'b: a -> (a ~> b) ~> b
 }
 
 Int: {
   type t = int
-  (==): t -> t -> bool
-  (<>): t -> t -> bool
-  (<): t -> t -> bool
-  (>): t -> t -> bool
-  (<=): t -> t -> bool
-  (>=): t -> t -> bool
-  (+): t -> t -> t
-  (-): t -> t -> t
-  (*): t -> t -> t
-  (/): t -> t -> t
-  (%): t -> t -> t
+  % * + - / : t -> t -> t
+  < <= <> == > >= : t -> t -> bool
   toText: t -> text
   print: t ~> {}
 }
@@ -62,8 +50,8 @@ Int: {
 List: {
   type t _
   nil 'a: t a
-  (::) 'a: a -> t a -> t a
-  case 'a 'o: {nil: o, (::): a ~> t a ~> o} -> t a ~> o
+  :: 'a: a -> t a -> t a
+  case 'a 'o: {nil: o, :: : a ~> t a ~> o} -> t a ~> o
 }
 
 Opt: {
@@ -87,13 +75,8 @@ System: {
 
 Text: {
   type t = text
-  (==): t -> t -> bool
-  (<>): t -> t -> bool
-  (<): t -> t -> bool
-  (>): t -> t -> bool
-  (<=): t -> t -> bool
-  (>=): t -> t -> bool
-  (++): t -> t -> t
+  ++ : t -> t -> t
+  < <= <> == > >= : t -> t -> bool
   length: t -> int
   sub: t -> int -> char
   fromChar: char -> t
@@ -113,29 +96,20 @@ type opt a = Opt.t a
 type text = Text.t
 type zero = Zero.t
 
-(%): int -> int -> int
-(*): int -> int -> int
-(+): int -> int -> int
-(++): text -> text -> text
-(-): int -> int -> int
-(/): int -> int -> int
-(::) 'a: a -> list a -> list a
-(<): int -> int -> bool
-(<<) 'a 'b 'c: (b ~> c) -> (a ~> b) -> a ~> c
-(<=): int -> int -> bool
-(<>): int -> int -> bool
-(<|) 'a 'b: (a ~> b) -> a ~> b
-(==): int -> int -> bool
-(>): int -> int -> bool
-(>=): int -> int -> bool
-(>>) 'a 'b 'c: (a ~> b) -> (b ~> c) -> a ~> c
-(|>) 'a 'b: a -> (a ~> b) ~> b
+% * + - / : int -> int -> int
+++ : text -> text -> text
+:: 'a: a -> list a -> list a
+< <= <> == > >= : int -> int -> bool
+<< 'a 'b 'c: (b ~> c) -> (a ~> b) -> a ~> c
+>> 'a 'b 'c: (a ~> b) -> (b ~> c) -> a ~> c
+<| 'a 'b: (a ~> b) -> a ~> b
+|> 'a 'b: a -> (a ~> b) ~> b
 bot 'a 'b: a -> b
 const 'a 'b: a -> b -> a
 cross 'a 'b 'c 'd: (a ~> c) -> (b ~> d) -> (a, b) ~> (c, d)
 curry 'a 'b 'c: ((a, b) ~> c) -> a -> b ~> c
 either 'a 'b 'o: (a ~> o) -> (b ~> o) -> alt a b ~> o
-false: bool
+false true: bool
 flip 'a 'b 'c: (a ~> b ~> c) -> b -> a ~> c
 fork 'a 'b 'c: (a ~> b) -> (a ~> c) -> a ~> (b, c)
 fst 'a 'b: (a, b) -> a
@@ -149,5 +123,4 @@ plus 'a 'b 'c 'd: (a ~> c) -> (b ~> d) -> alt a b ~> alt c d
 print: text ~> {}
 snd 'a 'b: (a, b) -> b
 some 'a: a -> opt a
-true: bool
 uncurry 'a 'b 'c: (a ~> b ~> c) -> (a, b) ~> c

--- a/prelude/primitives.1ml
+++ b/prelude/primitives.1ml
@@ -2,8 +2,8 @@ local
   pbo (p: _ -> _) l r = p (l, r)
 
   PolyEq (type t) = {
-    (==) = pbo (primitive "==" t)
-    (<>) = pbo (primitive "<>" t)
+    == = pbo (primitive "==" t)
+    <> = pbo (primitive "<>" t)
   }
 
 type bool = primitive "bool"
@@ -29,26 +29,26 @@ System = {
 }
 
 Int = {
-  (+) = pbo primitive "Int.+"
-  (-) = pbo primitive "Int.-"
-  (*) = pbo primitive "Int.*"
-  (/) = pbo primitive "Int./"
-  (%) = pbo primitive "Int.%"
-  (<) = pbo primitive "Int.<"
-  (>) = pbo primitive "Int.>"
-  (<=) = pbo primitive "Int.<="
-  (>=) = pbo primitive "Int.>="
+  + = pbo primitive "Int.+"
+  - = pbo primitive "Int.-"
+  * = pbo primitive "Int.*"
+  / = pbo primitive "Int./"
+  % = pbo primitive "Int.%"
+  < = pbo primitive "Int.<"
+  > = pbo primitive "Int.>"
+  <= = pbo primitive "Int.<="
+  >= = pbo primitive "Int.>="
   toText = primitive "Int.toText"
   print = primitive "Int.print"
   ...PolyEq int
 }
 
 Text = {
-  (++) = pbo primitive "Text.++"
-  (<) = pbo primitive "Text.<"
-  (>) = pbo primitive "Text.>"
-  (<=) = pbo primitive "Text.<="
-  (>=) = pbo primitive "Text.>="
+  ++ = pbo primitive "Text.++"
+  < = pbo primitive "Text.<"
+  > = pbo primitive "Text.>"
+  <= = pbo primitive "Text.<="
+  >= = pbo primitive "Text.>="
   length = primitive "Text.length"
   sub = pbo primitive "Text.sub"
   fromChar = primitive "Text.fromChar"

--- a/regression.1ml
+++ b/regression.1ml
@@ -54,9 +54,9 @@ Equivalence: {
 
 ;;
 
-type MONOID = {type t, empty: t, (++): t -> t ~> t}
+type MONOID = {type t, empty: t, ++ : t -> t ~> t}
 cat (M: MONOID) = List.foldl M.++ M.empty
-do assert (cat {empty = 0, (++) = (+)} (40 :: (2 :: nil)) == 42)
+do assert (cat {empty = 0, ++ = (+)} (40 :: (2 :: nil)) == 42)
 
 Poly: {type t} = {} ;; Poly 'x = {type t = x}
 do 1: Poly.t
@@ -266,7 +266,7 @@ Alt = Alt : {
   ...(= Alt)
   type a | b = alt a b
 }
-(|) = Alt.|
+| = Alt.|
 
 type AnAlt = {x: int} | {y: bool}
 
@@ -318,8 +318,8 @@ N :> {
 
 ListN = let
   type I (type x) (type p _) (type t _ _) = {
-    nil     :               p N.Z
-    (::) 'n : x ~> t x n ~> p (N.S n)
+    nil   :               p N.Z
+    :: 'n : x ~> t x n ~> p (N.S n)
   }
 in {
   ...rec {type t _ _} => {type t x n = wrap (type p _) -> I x p t ~> p n}
@@ -334,8 +334,8 @@ in {
 
   case 'x 'n: (type p _) -> I x p t -> t x n ~> p n
 
-  nil  'x    :               t x N.Z
-  (::) 'x 'n : x -> t x n -> t x (N.S n)
+  nil 'x    :               t x N.Z
+  ::  'x 'n : x -> t x n -> t x (N.S n)
 }
 
 ListN = {

--- a/syntax.ml
+++ b/syntax.ml
@@ -335,6 +335,13 @@ let rollP(p, t2) =
    annot = Some t2}
 
 
+(* *)
+
+let seqDs = function
+  | [] -> EmptyD
+  | d::ds -> (List.fold_left (fun s d -> seqD(s, d)@@d.at) d ds).it
+
+
 (* String conversion *)
 
 let node label = function

--- a/talk.1ml
+++ b/talk.1ml
@@ -32,9 +32,9 @@ type EQ = {
 type MAP = {
   type key
   type map a
-  empty a : map a
-  lookup a : key -> map a ~> opt a
-  add a : key -> a -> map a ~> map a
+  empty : (a : type) -> map a
+  lookup : (a : type) -> key -> map a ~> opt a
+  add : (a : type) -> key -> a -> map a ~> map a
 }
 
 Map (Key : EQ) :> MAP with (type key = Key.t) = {


### PR DESCRIPTION
Syntax of names is changed such that in simple declaration and binding contexts the parentheses around a symbol can be omitted.  For example, previously one would write:

    {(+), (-)} = Int
    (+): int -> int -> int

Now one can also write:

    {+, -} = Int
    + : int -> int -> int

Parentheses are still required when declaring symbol named functions:

    type (|) a b = ;; ...
    (+) x y = ;; ...

Of course, the infix notation can still also be used:

    type a | n = ;; ...
    x + y = ;; ...

Syntax of declarations is also changed such that multiple names can be declared with the same type.  Previously one would write:

    (+): int -> int -> int
    (-): int -> int -> int

Now one can also write:

    + - : int -> int -> int

To make this possible, only implicit type parameters are allowed before the colon.  Previously one could write:

    id a: a -> a

Now one must write:

    id: (a : type) -> a -> a

Implicit type parameters are still allowed before the colon:

    id 'a: a -> a

As explicit type parameters preceding the colon are a relic from 1ML without type inference this should not cause major inconvenience.

Syntax of paths (namelists) is also changed to allow symbols without parentheses.